### PR TITLE
use NUMERIC instead of INT

### DIFF
--- a/database/vmaas_db_postgresql.sql
+++ b/database/vmaas_db_postgresql.sql
@@ -6,7 +6,7 @@
 -- and most importantly sorting
 -- -----------------------------------------------------
 create type evr_array_item as (
-        n       INT,
+        n       NUMERIC,
         s       VARCHAR(512)
 );
 


### PR DESCRIPTION
vmaas=> select rpmver_array('3.6.0.v20120721114722');
ERROR:  integer out of range
CONTEXT:  PL/pgSQL function rpmver_array(character varying) line 52 at assignment