### PR TITLE
add table errata_repo

### DIFF
--- a/database/vmaas_db_postgresql.sql
+++ b/database/vmaas_db_postgresql.sql
@@ -243,6 +243,22 @@ CREATE TABLE IF NOT EXISTS errata (
 
 
 -- -----------------------------------------------------
+-- Table vmaas.errata_repo
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS errata_repo (
+  errata_id INT NOT NULL,
+  repo_id INT NOT NULL,
+  UNIQUE (errata_id, repo_id),
+  CONSTRAINT errata_id
+    FOREIGN KEY (errata_id)
+    REFERENCES errata (id),
+  CONSTRAINT repo_id
+    FOREIGN KEY (repo_id)
+    REFERENCES repo (id)
+)TABLESPACE pg_default;
+
+
+-- -----------------------------------------------------
 -- Table vmaas.pkg_errata
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS pkg_errata (


### PR DESCRIPTION
Even if the current errata evaluation algorithm doesn't need information from this table, it's needed to track this reference.

For example, text-only errata need to store this reference into DB to know where they came from.
It'll allow to simply list repositories or products containing given erratum without selecting over packages.