### PR TITLE
Fixing various issues in updateinfo parsing/importing

### DIFF
--- a/reposcan/database/update_store.py
+++ b/reposcan/database/update_store.py
@@ -194,7 +194,7 @@ class UpdateStore:
         to_associate = []
         for update in updates:
             update_id = update_map[update["id"]]
-            for cve in [cve["id"] for cve in update["references"] if cve["type"] == "cve"]:
+            for cve in set([cve["id"] for cve in update["references"] if cve["type"] == "cve"]):
                 cve_id = cve_map[cve]
                 if update_id in update_to_cves and cve_id in update_to_cves[update_id]:
                     # Already associated, remove from set
@@ -214,7 +214,7 @@ class UpdateStore:
 
         if to_associate:
             execute_values(cur, "insert into errata_cve (errata_id, cve_id) values %s",
-                           list(to_associate), page_size=len(to_associate))
+                           to_associate, page_size=len(to_associate))
 
         if to_disassociate:
             cur.execute("delete from errata_cve where (errata_id, cve_id) in %s", (tuple(to_disassociate),))

--- a/reposcan/repodata/updateinfo.py
+++ b/reposcan/repodata/updateinfo.py
@@ -21,9 +21,9 @@ class UpdateInfoMD:
                 update["description"] = elem.find("description").text
 
                 # Optional fields
-                updated = elem.find("issued")
-                if updated is not None:
-                    update["issued"] = updated.get("date")
+                issued = elem.find("issued")
+                if issued is not None:
+                    update["issued"] = issued.get("date")
                 else:
                     update["issued"] = None
 

--- a/reposcan/repodata/updateinfo.py
+++ b/reposcan/repodata/updateinfo.py
@@ -18,9 +18,14 @@ class UpdateInfoMD:
                 update["title"] = elem.find("title").text
                 update["summary"] = elem.find("summary").text
                 update["rights"] = elem.find("rights").text
-                update["description"] = elem.find("description").text
 
                 # Optional fields
+                description = elem.find("description")
+                if description is not None:
+                    update["description"] = description.text
+                else:
+                    update["description"] = None
+
                 issued = elem.find("issued")
                 if issued is not None:
                     update["issued"] = issued.get("date")


### PR DESCRIPTION
1. Variable name updated should be called issued (this change has no effect on functionality)
2. Description field can be undefined sometimes (https://access.redhat.com/errata/RHEA-2003:018)
2. Make sure CVE-erratum associations are not duplicated in insert query (https://access.redhat.com/errata/RHSA-2005:802).