### PR TITLE
Few fixes

### DIFF
--- a/reposcan/database/package_store.py
+++ b/reposcan/database/package_store.py
@@ -111,6 +111,8 @@ class PackageStore:
                 if (checksum_types[pkg["checksum_type"]], pkg["checksum"]) in checksums:
                     import_data.append((pkg["name"], evr_map[(pkg["epoch"], pkg["ver"], pkg["rel"])],
                                         archs[pkg["arch"]], checksum_types[pkg["checksum_type"]], pkg["checksum"]))
+                    # Prevent duplicated insert when some package is multiple times in metadata
+                    checksums.remove((checksum_types[pkg["checksum_type"]], pkg["checksum"]))
             execute_values(cur,
                            """insert into package (name, evr_id, arch_id, checksum_type_id, checksum) values %s
                               returning id, checksum_type_id, checksum""",

--- a/reposcan/download/unpacker.py
+++ b/reposcan/download/unpacker.py
@@ -46,4 +46,6 @@ class FileUnpacker:
         self.logger.log("Unpacking started.")
         for file_path in self.queue:
             self._unpack(file_path)
+        # Make queue empty to be able to reuse this class multiple times in one run
+        self.queue = []
         self.logger.log("Unpacking finished.")

--- a/reposcan/repodata/repository_controller.py
+++ b/reposcan/repodata/repository_controller.py
@@ -89,6 +89,7 @@ class RepositoryController:
                 repository.tmp_directory = None
 
     def add_repository(self, repo_url):
+        repo_url = repo_url.strip()
         if not repo_url.endswith("/"):
             repo_url += "/"
         self.repositories.append(Repository(repo_url))

--- a/reposcan/repodata/updateinfo.py
+++ b/reposcan/repodata/updateinfo.py
@@ -16,10 +16,20 @@ class UpdateInfoMD:
                 update["type"] = elem.get("type")
                 update["id"] = elem.find("id").text
                 update["title"] = elem.find("title").text
-                update["summary"] = elem.find("summary").text
-                update["rights"] = elem.find("rights").text
 
                 # Optional fields
+                summary = elem.find("summary")
+                if summary is not None:
+                    update["summary"] = summary.text
+                else:
+                    update["summary"] = None
+
+                rights = elem.find("rights")
+                if rights is not None:
+                    update["rights"] = rights.text
+                else:
+                    update["rights"] = None
+
                 description = elem.find("description")
                 if description is not None:
                     update["description"] = description.text

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -19,6 +19,7 @@ if __name__ == '__main__':
                         default="5432")
     parser.add_argument("-r", "--repo", action="append",
                         help="Sync given repository (can be specifed multiple times).")
+    parser.add_argument("--repofile", action="store", help="Read repository list from file.")
     args = parser.parse_args()
 
     # Setup DB connection parameters
@@ -28,8 +29,12 @@ if __name__ == '__main__':
     DatabaseHandler.db_host = args.db_host
     DatabaseHandler.db_port = args.db_port
 
+    repository_controller = RepositoryController()
     if args.repo:
-        repository_controller = RepositoryController()
         for repo_url in args.repo:
             repository_controller.add_repository(repo_url)
-        repository_controller.store()
+    if args.repofile:
+        with open(args.repofile, "r") as repo_file:
+            for line in repo_file.readlines():
+                repository_controller.add_repository(line)
+    repository_controller.store()


### PR DESCRIPTION
1. Add possibility to pass repository list in file. (this is useful as long as this is command line app)
2. Split repository into batches of 100 elements (this count will be adjustable in future). When syncing lot of repositories this prevents to run out of disk space.
3. Fix bug in unpacker queue - the queue is not empty after first run.
4. Some repos can have some package specified twice (probably a bug) but in DB are unique constraints. This fixes it.
5. Evaluate HTTPS status code of downloaded file and skip repository when repomd failed to download.
6. summary and rights fields can be undefined in some old repositories. (example in commit message)