### PR TITLE
make sure all texts inside XML elements are stripped

### DIFF
--- a/reposcan/repodata/primary.py
+++ b/reposcan/repodata/primary.py
@@ -15,15 +15,15 @@ class PrimaryMD:
             elif elem.tag == "{%s}package" % NS["primary"] and event == "end":
                 if elem.get("type") == "rpm":
                     package = {}
-                    package["name"] = elem.find("primary:name", NS).text
+                    package["name"] = elem.find("primary:name", NS).text.strip()
                     evr = elem.find("primary:version", NS)
                     package["epoch"] = evr.get("epoch")
                     package["ver"] = evr.get("ver")
                     package["rel"] = evr.get("rel")
-                    package["arch"] = elem.find("primary:arch", NS).text
+                    package["arch"] = elem.find("primary:arch", NS).text.strip()
                     checksum = elem.find("primary:checksum", NS)
                     package["checksum_type"] = checksum.get("type")
-                    package["checksum"] = checksum.text
+                    package["checksum"] = checksum.text.strip()
                     self.packages.append(package)
                     # Clear the XML tree continuously
                     root.clear()

--- a/reposcan/repodata/repomd.py
+++ b/reposcan/repodata/repomd.py
@@ -17,9 +17,9 @@ class RepoMD:
         for child in root.findall("repo:data", NS):
             data_type = child.get("type")
             location = child.find("repo:location", NS).get("href")
-            size = int(child.find("repo:size", NS).text)
+            size = int(child.find("repo:size", NS).text.strip())
             checksum_type = child.find("repo:checksum", NS).get("type")
-            checksum = child.find("repo:checksum", NS).text
+            checksum = child.find("repo:checksum", NS).text.strip()
             self.data[data_type] = {"location": location, "size": size,
                                     "checksum_type": checksum_type, "checksum": checksum}
 

--- a/reposcan/repodata/updateinfo.py
+++ b/reposcan/repodata/updateinfo.py
@@ -14,25 +14,25 @@ class UpdateInfoMD:
                 update["status"] = elem.get("status")
                 update["version"] = elem.get("version")
                 update["type"] = elem.get("type")
-                update["id"] = elem.find("id").text
-                update["title"] = elem.find("title").text
+                update["id"] = elem.find("id").text.strip()
+                update["title"] = elem.find("title").text.strip()
 
                 # Optional fields
                 summary = elem.find("summary")
                 if summary is not None:
-                    update["summary"] = summary.text
+                    update["summary"] = summary.text.strip()
                 else:
                     update["summary"] = None
 
                 rights = elem.find("rights")
                 if rights is not None:
-                    update["rights"] = rights.text
+                    update["rights"] = rights.text.strip()
                 else:
                     update["rights"] = None
 
                 description = elem.find("description")
                 if description is not None:
-                    update["description"] = description.text
+                    update["description"] = description.text.strip()
                 else:
                     update["description"] = None
 
@@ -50,19 +50,19 @@ class UpdateInfoMD:
 
                 release = elem.find("release")
                 if release is not None:
-                    update["release"] = release.text
+                    update["release"] = release.text.strip()
                 else:
                     update["release"] = None
 
                 solution = elem.find("solution")
                 if solution is not None:
-                    update["solution"] = solution.text
+                    update["solution"] = solution.text.strip()
                 else:
                     update["solution"] = None
 
                 severity = elem.find("severity")
                 if severity is not None:
-                    update["severity"] = severity.text
+                    update["severity"] = severity.text.strip()
                 else:
                     update["severity"] = None
 


### PR DESCRIPTION
e.g. updateinfo in /content/dist/rhel/rhui/server/6/6Server/x86_64/rhscl/1/os repository contains trailing whitespaces

fixing #28, example:

```
<tag>text inside
</tag>
```

will be parsed as "text inside", without the newline.