### PR TITLE
Filter repositories based on timestamp + some fixes

### DIFF
--- a/reposcan/common/batch_list.py
+++ b/reposcan/common/batch_list.py
@@ -1,0 +1,25 @@
+DEFAULT_BATCH_SIZE = 100
+
+
+class BatchList:
+    """List of lists with defined maximum size of inner lists."""
+
+    def __init__(self, max_batch_size=DEFAULT_BATCH_SIZE):
+        self.max_batch_size = max_batch_size
+        self.batches = []
+
+    def __iter__(self):
+        return iter(self.batches)
+
+    def clear(self):
+        self.batches = []
+
+    def add_item(self, item):
+        if len(self.batches) > 0:
+            last_batch = self.batches[-1]
+        else:
+            last_batch = None
+        if last_batch is None or len(last_batch) >= self.max_batch_size:
+            last_batch = []
+            self.batches.append(last_batch)
+        last_batch.append(item)

--- a/reposcan/database/repository_store.py
+++ b/reposcan/database/repository_store.py
@@ -39,10 +39,7 @@ class RepositoryStore:
         return repo_id[0]
 
     def store(self, repository):
-        if repository.repomd:
-            self.logger.log("Syncing repository: %s" % repository.repo_url)
-            repo_id = self._import_repository(repository.repo_url, repository.repomd.get_revision())
-            self.package_store.store(repo_id, repository.list_packages())
-            self.update_store.store(repo_id, repository.list_updates())
-        else:
-            self.logger.log("Skipping repository: %s" % repository.repo_url)
+        self.logger.log("Syncing repository: %s" % repository.repo_url)
+        repo_id = self._import_repository(repository.repo_url, repository.repomd.get_revision())
+        self.package_store.store(repo_id, repository.list_packages())
+        self.update_store.store(repo_id, repository.list_updates())

--- a/reposcan/repodata/repository.py
+++ b/reposcan/repodata/repository.py
@@ -1,4 +1,7 @@
 from cli.logger import SimpleLogger
+from repodata.primary import PrimaryMD
+from repodata.primary_db import PrimaryDatabaseMD
+from repodata.updateinfo import UpdateInfoMD
 
 
 class Repository:
@@ -30,3 +33,16 @@ class Repository:
                 return [u for u in self.updateinfo.list_updates() if u["type"] == update_type]
             return self.updateinfo.list_updates()
         return []
+
+    def load_metadata(self):
+        for md_type in self.md_files:
+            if md_type == "primary_db":
+                self.primary = PrimaryDatabaseMD(self.md_files["primary_db"])
+            elif md_type == "primary":
+                self.primary = PrimaryMD(self.md_files["primary"])
+            elif md_type == "updateinfo":
+                self.updateinfo = UpdateInfoMD(self.md_files["updateinfo"])
+
+    def unload_metadata(self):
+        self.primary = None
+        self.updateinfo = None


### PR DESCRIPTION
1. Use stored revision timestamp from DB to filter out not updated repositories.
2. Optimize downloading in batches - download all repomd files first at once (their disk space usage is marginal) and then sort out into batches only passed repositories, it helps in case when for example 10000 repomd files are downloaded but only 5 of them needs update, this way these 5 repositories can be processed in single batch.
3. Refactoring, put these two functions inside repository class as it makes better sense.
4. Add more log messages.