### PR TITLE
run dummy_crawler in infinite loop.

### DIFF
--- a/reposcan/dummy_crawler.sh
+++ b/reposcan/dummy_crawler.sh
@@ -1,23 +1,28 @@
 #!/bin/bash
 
-REPOS=(http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7.4/x86_64/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/optional/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7.4/x86_64/optional/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/6/6Server/x86_64/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/6/6.9/x86_64/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/6/6Server/x86_64/optional/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/6/6.9/x86_64/optional/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/7/7Workstation/x86_64/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/7/7.4/x86_64/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/7/7Workstation/x86_64/optional/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/7/7.4/x86_64/optional/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/6/6Workstation/x86_64/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/6/6.9/x86_64/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/6/6Workstation/x86_64/optional/os/ \
-http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/6/6.9/x86_64/optional/os/)
+while true; do
+	REPOS=(http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7.4/x86_64/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/optional/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7.4/x86_64/optional/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/6/6Server/x86_64/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/6/6.9/x86_64/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/6/6Server/x86_64/optional/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/6/6.9/x86_64/optional/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/7/7Workstation/x86_64/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/7/7.4/x86_64/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/7/7Workstation/x86_64/optional/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/7/7.4/x86_64/optional/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/6/6Workstation/x86_64/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/6/6.9/x86_64/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/6/6Workstation/x86_64/optional/os/ \
+		http://pulp-read.dist.prod.ext.phx2.redhat.com/content/dist/rhel/workstation/6/6.9/x86_64/optional/os/)
 
 
-for r in ${REPOS[*]}; do
-	cd /vmaas-reposcan && ./reposcan.py -d $POSTGRES_DB -H $POSTGRES_HOST -U $POSTGRES_USER -P $POSTGRES_PASSWORD -r $r
+	for r in ${REPOS[*]}; do
+		cd /vmaas-reposcan && ./reposcan.py -d $POSTGRES_DB -H $POSTGRES_HOST -U $POSTGRES_USER -P $POSTGRES_PASSWORD -r $r
+	done
+
+	# sleep for an hour
+	sleep 3600
 done


### PR DESCRIPTION
Just add a workaround for the workaround :) 

dummy_crawler is our temporary solution to crawl through a list of repositories and collect repodata. In the future versions, we are going to use a real crawler which will be triggered by service. For now, I added the infinite loop to the dummy_crawler just to keep container running.