### PR TITLE
add product ID column

### DIFF
--- a/database/vmaas_db_postgresql.sql
+++ b/database/vmaas_db_postgresql.sql
@@ -181,7 +181,8 @@ CREATE TABLE IF NOT EXISTS package (
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS product (
   id SERIAL,
-  name TEXT NOT NULL UNIQUE,
+  eng_product_id INT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
   PRIMARY KEY (id)
 )TABLESPACE pg_default;
 


### PR DESCRIPTION
This table is not filled with data yet. Add INT column to store engineering product ID here.

Example:
eng_product_id: 69
name: "Red Hat Enterprise Linux Server"