### PR TITLE
save downloaded files outside the application container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
       - vmaas-db-data:/var/lib/pgsql/data
 
   reposcan:
+    labels:
+      kompose.volume.size: 5Gi
     container_name: vmaas-reposcan
     build: ./reposcan
     image: vmaas/reposcan
@@ -23,6 +25,8 @@ services:
       - ./docker-compose.env
     ports:
       - 8081:8081
+    volumes:
+      - vmaas-reposcan-tmp:/tmp
     depends_on:
       - database
     links:
@@ -43,3 +47,4 @@ services:
       - database
 volumes:
   vmaas-db-data:
+  vmaas-reposcan-tmp:


### PR DESCRIPTION
Downloaded and decompressed repodata can be too big for application container in OpenShift, store them in a dedicated storage.