### PR TITLE
api: updates: skip only updates w/o erratum associated.

### DIFF
--- a/webapp/updates.py
+++ b/webapp/updates.py
@@ -264,15 +264,14 @@ def process_list(cursor, packages_to_process):
         if 'update_id' not in auxiliary_dict[pkg]:
             continue
 
-        # Some pkgs don't have associated errata (eg, original-repo-content) - skip
-        # resulting KeyError
-        try:
-            for upd_pkg_id in auxiliary_dict[pkg]['update_id']:
-                # FIXME: use compatibility tables instead of exact matching
-                if auxiliary_dict[pkg]['arch_id'] == pkg_id2arch_id[upd_pkg_id]:
-                    for r_id in pkg_id2repo_id[upd_pkg_id]:
-                        # check if update package in the same repo with original one
-                        if r_id in auxiliary_dict[pkg]['repo_id']:
+        for upd_pkg_id in auxiliary_dict[pkg]['update_id']:
+            # FIXME: use compatibility tables instead of exact matching
+            if auxiliary_dict[pkg]['arch_id'] == pkg_id2arch_id[upd_pkg_id]:
+                for r_id in pkg_id2repo_id[upd_pkg_id]:
+                    # check if update package in the same repo with original one
+                    if r_id in auxiliary_dict[pkg]['repo_id']:
+                        # Some pkgs don't have associated errata (eg, original-repo-content)
+                        if upd_pkg_id in pkg_id2errata_id:
                             errata_ids = pkg_id2errata_id[upd_pkg_id]
                             for e_id in errata_ids:
                                 # check current errata in the same repo with update pkg
@@ -284,9 +283,6 @@ def process_list(cursor, packages_to_process):
                                         'package': pkg_id2full_name[upd_pkg_id],
                                         'erratum': e_name,
                                         'repository': r_name})
-        except KeyError:
-            pass
-
     return answer
 
 


### PR DESCRIPTION
Some updates could be w/o erratum associated. In this case, we should skip exactly this update package and do not stop processing other updates