### PR TITLE
Issue 67 - set connection to readonly and autocommit

### DIFF
--- a/webapp/database.py
+++ b/webapp/database.py
@@ -23,6 +23,7 @@ class Database:
                                          password=self.password,
                                          host=self.host,
                                          port=self.port)
+        self.connection.set_session(readonly=True, autocommit=True)
 
     def cursor(self):
         return self.connection.cursor()


### PR DESCRIPTION
This fixes the issue where an error during a database query results in no more ability to talk to the database.