### PR TITLE
api: use python json module from the standard library, instead of ujson from epel

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -8,7 +8,7 @@ ENV POSTGRESQL_USER=vmaas_user
 ENV POSTGRESQL_PASSWORD=vmaas_passwd
 ENV POSTGRESQL_DATABASE=vmaas
 
-RUN yum -y update && yum -y install epel-release && yum -y install python-ujson python-tornado python-psycopg2 postgresql && rm -rf /var/cache/yum/*
+RUN yum -y update && yum -y install python-tornado python-psycopg2 postgresql && rm -rf /var/cache/yum/*
 
 ADD ./wait-for-postgres.sh /app/wait-for-postgres.sh
 ADD ./entrypoint.sh /app/

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -2,8 +2,7 @@
 
 from tornado.ioloop import IOLoop
 import tornado.web
-import ujson
-import os
+import json
 
 from database import Database
 from cve import CveAPI
@@ -42,7 +41,7 @@ class JsonHandler(tornado.web.RequestHandler):
 
         # fill response with packages
         try:
-            data = ujson.loads(json_data)
+            data = json.loads(json_data)
             response = self.process_list(data)
             self.write(response)
         except ValueError:

--- a/webapp/repos.py
+++ b/webapp/repos.py
@@ -1,5 +1,3 @@
-import sys
-import ujson
 
 class RepoAPI:
     def __init__(self, cursor):

--- a/webapp/updates.py
+++ b/webapp/updates.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python -u
 
-import sys
-import ujson
 
 def split_filename(filename):
     """

--- a/webapp/vmaas
+++ b/webapp/vmaas
@@ -1,7 +1,7 @@
 #!/usr/bin/python -u
 
 import argparse
-import ujson
+import json
 import sys
 
 from database import Database
@@ -49,7 +49,7 @@ def read_data(data_file, data_list, key):
     data = {}
     if data_file:
         with open(data_file, "r") as content:
-            data = ujson.loads(content.read())
+            data = json.loads(content.read())
 
     if data_list:
         if key not in data:
@@ -80,7 +80,7 @@ def main():
 
         answer = RepoAPI(cursor).process_list(data)
 
-    print(ujson.dumps(answer))
+    print(json.dumps(answer))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Since we are not using ujson anymore, 'epel' reposotory is also removed.

Removed some unused imports:
'import os' in webapp/app.py
'import sys' in webapp/repos.py