### PR TITLE
fix input package with invalid architecture

### DIFF
--- a/webapp/updates.py
+++ b/webapp/updates.py
@@ -117,7 +117,7 @@ class UpdatesAPI(object):
                 answer[pkg] = []          # fill answer with empty data
 
                 evr_key = e + ':' + v + ':' + r
-                if evr_key in self.evr2id_dict:
+                if evr_key in self.evr2id_dict and a in self.arch2id_dict:
                     packages_names.append(n)
                     auxiliary_dict[pkg][n] = []
 


### PR DESCRIPTION
example:

curl -X GET http://127.0.0.1:8080/api/v1/updates/kernel-2.6.32-696.18.7.el6.x87_74

```
vmaas-webapp | ERROR:tornado.application:Uncaught exception GET /api/v1/updates/kernel-2.6.32-696.18.7.el6.x87_74 (172.18.0.1)
vmaas-webapp | HTTPServerRequest(protocol='http', host='127.0.0.1:8080', method='GET', uri='/api/v1/updates/kernel-2.6.32-696.18.7.el6.x87_74', version='HTTP/1.1', remote_ip='172.18.0.1', headers={'Host': '127.0.0.1:8080', 'Accept': '*/*', 'User-Agent': 'curl/7.55.1'})
vmaas-webapp | Traceback (most recent call last):
vmaas-webapp |   File "/usr/lib64/python2.7/site-packages/tornado/web.py", line 1412, in _execute
vmaas-webapp |     result = method(*self.path_args, **self.path_kwargs)
vmaas-webapp |   File "/app/app.py", line 27, in get
vmaas-webapp |     response = self.process_string(name)
vmaas-webapp |   File "/app/app.py", line 60, in process_string
vmaas-webapp |     return self.application.updatesapi.process_list({'package_list': [data]})
vmaas-webapp |   File "/app/updates.py", line 127, in process_list
vmaas-webapp |     auxiliary_dict[pkg]['arch_id'] = self.arch2id_dict[a]
vmaas-webapp | KeyError: 'x87_74'
vmaas-webapp | ERROR:tornado.access:500 GET /api/v1/updates/kernel-2.6.32-696.18.7.el6.x87_74 (172.18.0.1) 0.60ms
```