### PR TITLE
specify internal port number in docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     env_file:
       - ./docker-compose.env
     ports:
+      - 8079
       - 8080:8080
     depends_on:
       - database


### PR DESCRIPTION
to propagate into openshift deployment config when processed by kompose tool