### PR TITLE
Add more errata data

### DIFF
--- a/database/vmaas_db_postgresql.sql
+++ b/database/vmaas_db_postgresql.sql
@@ -395,6 +395,19 @@ CREATE TABLE IF NOT EXISTS errata_cve (
 )TABLESPACE pg_default;
 
 -- -----------------------------------------------------
+-- Table vmaas.errata_refs
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS errata_refs (
+  errata_id INT NOT NULL,
+  type TEXT NOT NULL,
+  name TEXT NOT NULL,
+  UNIQUE (errata_id, type, name),
+  CONSTRAINT errata_id
+    FOREIGN KEY (errata_id)
+    REFERENCES errata (id)
+)TABLESPACE pg_default;
+
+-- -----------------------------------------------------
 -- Table vmaas.metadata
 -- -----------------------------------------------------
 -- This table holds different timestamps, checksums and


### PR DESCRIPTION
This finishes Issue #119.
It also reworks how the various lists of info in an erratum are retrieved - it makes 3 db queries to populate lists in all errata instead of 3 db queries per erratum.