### PR TITLE
update reposcan to use updated schema

### DIFF
--- a/database/vmaas_db_postgresql.sql
+++ b/database/vmaas_db_postgresql.sql
@@ -181,8 +181,8 @@ CREATE TABLE IF NOT EXISTS package (
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS product (
   id SERIAL,
-  redhat_eng_product_id INT NOT NULL UNIQUE,
-  name TEXT NULL,
+  name TEXT NOT NULL UNIQUE,
+  redhat_eng_product_id INT NULL UNIQUE,
   PRIMARY KEY (id)
 )TABLESPACE pg_default;
 

--- a/reposcan/README.md
+++ b/reposcan/README.md
@@ -39,78 +39,78 @@ JSON list of repositories have following format:
     "key": "<CLIENT KEY>"
   },
   "products": {
-    "69": {
-      "name": "Red Hat Enterprise Linux Server",
+    "Red Hat Enterprise Linux Server": {
+      "redhat_eng_product_id": 69,
       "content_sets": {
         "rhel-7-server-rpms": {
           "name": "Red Hat Enterprise Linux 7 Server (RPMs)",
-          "repos": {
-            "rhel-7-server-rpms__7Server__x86_64": "https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/",
-            "rhel-7-server-rpms__7_DOT_4__x86_64": "https://cdn.redhat.com/content/dist/rhel/server/7/7.4/x86_64/os/"
-          }
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["7Server", "7.4"]
         },
         "rhel-7-server-optional-rpms": {
           "name": "Red Hat Enterprise Linux 7 Server - Optional (RPMs)",
-          "repos": {
-            "rhel-7-server-optional-rpms__7Server__x86_64": "https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/optional/os/",
-            "rhel-7-server-optional-rpms__7_DOT_4__x86_64": "https://cdn.redhat.com/content/dist/rhel/server/7/7.4/x86_64/optional/os/"
-          }
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/optional/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["7Server", "7.4"]
         },
         "rhel-6-server-rpms": {
           "name": "Red Hat Enterprise Linux 6 Server (RPMs)",
-          "repos": {
-            "rhel-6-server-rpms__6Server__x86_64": "https://cdn.redhat.com/content/dist/rhel/server/6/6Server/x86_64/os/",
-            "rhel-6-server-rpms__6_DOT_9__x86_64": "https://cdn.redhat.com/content/dist/rhel/server/6/6.9/x86_64/os/"
-          }
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/server/6/$releasever/$basearch/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["6Server", "6.9"]
         },
         "rhel-6-server-optional-rpms": {
           "name": "Red Hat Enterprise Linux 6 Server - Optional (RPMs)",
-          "repos": {
-            "rhel-6-server-optional-rpms__6Server__x86_64": "https://cdn.redhat.com/content/dist/rhel/server/6/6Server/x86_64/optional/os/",
-            "rhel-6-server-optional-rpms__6_DOT_9__x86_64": "https://cdn.redhat.com/content/dist/rhel/server/6/6.9/x86_64/optional/os/"
-          }
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/server/6/$releasever/$basearch/optional/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["6Server", "6.9"]
         }
       }
     },
-    "71": {
-      "name": "Red Hat Enterprise Linux Workstation",
+    "Red Hat Enterprise Linux Workstation": {
+      "redhat_eng_product_id": 71,
       "content_sets": {
         "rhel-7-workstation-rpms": {
           "name": "Red Hat Enterprise Linux 7 Workstation (RPMs)",
-          "repos": {
-            "rhel-7-workstation-rpms__7Workstation__x86_64": "https://cdn.redhat.com/content/dist/rhel/workstation/7/7Workstation/x86_64/os/",
-            "rhel-7-workstation-rpms__7_DOT_4__x86_64": "https://cdn.redhat.com/content/dist/rhel/workstation/7/7.4/x86_64/os/"
-          }
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/workstation/7/$releasever/$basearch/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["7Workstation", "7.4"]
         },
         "rhel-7-workstation-optional-rpms": {
           "name": "Red Hat Enterprise Linux 7 Workstation - Optional (RPMs)",
-          "repos": {
-            "rhel-7-workstation-optional-rpms__7Workstation__x86_64": "https://cdn.redhat.com/content/dist/rhel/workstation/7/7Workstation/x86_64/optional/os/",
-            "rhel-7-workstation-optional-rpms__7_DOT_4__x86_64": "https://cdn.redhat.com/content/dist/rhel/workstation/7/7.4/x86_64/optional/os/"
-          }
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/workstation/7/$releasever/$basearch/optional/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["7Workstation", "7.4"]
         },
         "rhel-6-workstation-rpms": {
           "name": "Red Hat Enterprise Linux 6 Workstation (RPMs)",
-          "repos": {
-            "rhel-6-workstation-rpms__6Workstation__x86_64": "https://cdn.redhat.com/content/dist/rhel/workstation/6/6Workstation/x86_64/os/",
-            "rhel-6-workstation-rpms__6_DOT_9__x86_64": "https://cdn.redhat.com/content/dist/rhel/workstation/6/6.9/x86_64/os/"
-          }
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/workstation/6/$releasever/$basearch/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["6Workstation", "6.9"]
         },
         "rhel-6-workstation-optional-rpms": {
           "name": "Red Hat Enterprise Linux 6 Workstation - Optional (RPMs)",
-          "repos": {
-            "rhel-6-workstation-optional-rpms__6Workstation__x86_64": "https://cdn.redhat.com/content/dist/rhel/workstation/6/6Workstation/x86_64/optional/os/",
-            "rhel-6-workstation-optional-rpms__6_DOT_9__x86_64": "https://cdn.redhat.com/content/dist/rhel/workstation/6/6.9/x86_64/optional/os/"
-          }
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/workstation/6/$releasever/$basearch/optional/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["6Workstation", "6.9"]
         }
       }
     }
   }
 },
 {
-  "repos": {
-    "fedora-26-updates": "https://mirrors.nic.cz/fedora/linux/updates/26/x86_64/",
-    "fedora-27-updates": "https://mirrors.nic.cz/fedora/linux/updates/27/x86_64/"
+  "products": {
+    "Fedora": {
+      "content_sets": {
+        "updates": {
+          "name": "Fedora Updates",
+          "baseurl": "https://mirrors.nic.cz/fedora/linux/updates/$releasever/$basearch/",
+          "basearch": ["x86_64"],
+          "releasever": ["27"]
+        }
+      }
+    }
   }
 }]
 ```
@@ -124,6 +124,8 @@ Example commands:
 `$ curl -X GET http://127.0.0.1:8081/api/v1/sync/repo`
 
 `$ curl -X GET http://127.0.0.1:8081/api/v1/sync/cve`
+
+`$ curl -X GET http://127.0.0.1:8081/api/v1/sync`
 
 This allows to control the reposcan container manually.
 

--- a/reposcan/database/repository_store.py
+++ b/reposcan/database/repository_store.py
@@ -30,18 +30,31 @@ class RepositoryStore:
     def list_repositories(self):
         """List repositories stored in DB. Dictionary with repository label as key is returned."""
         cur = self.conn.cursor()
-        cur.execute("""select r.id, r.label, r.url, r.revision, cs.id, cs.label, c.name, c.ca_cert, c.cert, c.key
+        cur.execute("""select cs.label, a.name, r.releasever, r.id, r.url, r.revision, cs.id,
+                              c.name, c.ca_cert, c.cert, c.key
                        from repo r
+                       left join arch a on r.basearch_id = a.id
                        left join certificate c on r.certificate_id = c.id
                        left join content_set cs on r.content_set_id = cs.id""")
         repos = {}
         for row in cur.fetchall():
-            # repo_label -> repo_id, repo_url, repo_revision
-            repos[row[1]] = {"id": row[0], "url": row[2], "revision": row[3], "content_set_id": row[4],
-                             "content_set": row[5], "cert_name": row[6], "ca_cert": row[7], "cert": row[8],
-                             "key": row[9]}
+            # (content_set_label, repo_arch, repo_releasever) -> repo_id, repo_url, repo_revision...
+            repos[(row[0], row[1], row[2])] = {"id": row[3], "url": row[4], "revision": row[5],
+                                               "content_set_id": row[6], "cert_name": row[7], "ca_cert": row[8],
+                                               "cert": row[9], "key": row[10]}
         cur.close()
         return repos
+
+    def _import_basearch(self, basearch):
+        cur = self.conn.cursor()
+        cur.execute("select id from arch where name = %s", (basearch,))
+        arch_id = cur.fetchone()
+        if not arch_id:
+            cur.execute("insert into arch (name) values(%s) returning id", (basearch,))
+            arch_id = cur.fetchone()
+        cur.close()
+        self.conn.commit()
+        return arch_id[0]
 
     def _import_certificate(self, cert_name, ca_cert, cert, key):
         cur = self.conn.cursor()
@@ -63,19 +76,25 @@ class RepositoryStore:
             cert_id = self._import_certificate(repo.cert_name, repo.ca_cert, repo.cert, repo.key)
         else:
             cert_id = None
-        cur = self.conn.cursor()
-        cur.execute("select id from repo where label = %s", (repo.repo_label,))
-        repo_id = cur.fetchone()
+        basearch_id = self._import_basearch(repo.basearch)
         content_set_id = self._get_content_set_id(repo)
+        cur = self.conn.cursor()
+        cur.execute("select id from repo where content_set_id = %s and basearch_id = %s and releasever = %s",
+                    (content_set_id, basearch_id, repo.releasever))
+        repo_id = cur.fetchone()
         if not repo_id:
-            cur.execute("""insert into repo (label, url, revision, eol, certificate_id, content_set_id)
-                        values (%s, %s, to_timestamp(%s), false, %s, %s) returning id""",
-                        (repo.repo_label, repo.repo_url, repo.repomd.get_revision(), cert_id, content_set_id,))
+            cur.execute("""insert into repo (url, content_set_id, basearch_id, releasever,
+                                             revision, eol, certificate_id)
+                        values (%s, %s, %s, %s, to_timestamp(%s), false, %s) returning id""",
+                        (repo.repo_url, content_set_id, basearch_id, repo.releasever,
+                         repo.repomd.get_revision(), cert_id,))
             repo_id = cur.fetchone()
         else:
             # Update repository timestamp
-            cur.execute("""update repo set revision = to_timestamp(%s), certificate_id = %s, content_set_id = %s
-                        where id = %s""", (repo.repomd.get_revision(), cert_id, content_set_id, repo_id[0],))
+            cur.execute("""update repo set revision = to_timestamp(%s), certificate_id = %s, content_set_id = %s,
+                                           basearch_id = %s, releasever = %s
+                        where id = %s""", (repo.repomd.get_revision(), cert_id, content_set_id, basearch_id,
+                                           repo.releasever, repo_id[0],))
         cur.close()
         self.conn.commit()
         return repo_id[0]
@@ -86,7 +105,8 @@ class RepositoryStore:
         First, basic repository info is processed, then all packages, then all updates.
         Some steps may be skipped if given data doesn't exist or are already synced.
         """
-        self.logger.log("Syncing repository: %s" % repository.repo_label)
+        self.logger.log("Syncing repository: %s" % ", ".join((repository.content_set, repository.basearch,
+                                                              repository.releasever)))
         repo_id = self._import_repository(repository)
         self.package_store.store(repo_id, repository.list_packages())
         self.update_store.store(repo_id, repository.list_updates())

--- a/reposcan/repodata/repository.py
+++ b/reposcan/repodata/repository.py
@@ -12,9 +12,8 @@ class Repository:
     Class aggregating information about metadata files available in repository.
     """
     # pylint: disable=too-many-arguments, too-many-instance-attributes
-    def __init__(self, repo_label, repo_url, content_set=None, cert_name=None, ca_cert=None, cert=None, key=None):
+    def __init__(self, repo_url, content_set, basearch, releasever, cert_name=None, ca_cert=None, cert=None, key=None):
         self.logger = SimpleLogger()
-        self.repo_label = repo_label
         self.repo_url = repo_url
         self.repomd = None
         self.primary = None
@@ -22,6 +21,8 @@ class Repository:
         self.md_files = {}
         self.tmp_directory = None
         self.content_set = content_set
+        self.basearch = basearch
+        self.releasever = releasever
         self.cert_name = cert_name
         self.ca_cert = ca_cert
         self.cert = cert

--- a/reposcan/repodata/test/test_repository.py
+++ b/reposcan/repodata/test/test_repository.py
@@ -17,12 +17,12 @@ class TestRepository(unittest.TestCase):
         primary = PrimaryMD("test_data/repodata/primary.xml")
         updateinfo = UpdateInfoMD("test_data/repodata/updateinfo.xml")
 
-        self.repository = Repository("repo_label", "repo_url")
+        self.repository = Repository("repo_url", "content_set", "x86_64", "27")
         self.repository.primary = primary_db
         self.repository.updateinfo = updateinfo
-        self.repository_without_updateinfo = Repository("repo_label", "repo_url")
+        self.repository_without_updateinfo = Repository("repo_url", "content_set", "x86_64", "27")
         self.repository_without_updateinfo.primary = primary_db
-        self.repository_primary_xml = Repository("repo_label", "repo_url")
+        self.repository_primary_xml = Repository("repo_url", "content_set", "x86_64", "27")
         self.repository_primary_xml.primary = primary
         self.repository_primary_xml.updateinfo = updateinfo
 

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -189,19 +189,14 @@ class RepoSyncHandler(SyncHandler):
             else:
                 cert_name, ca_cert, cert, key = None, None, None, None
 
-            # Repository list without product and content set information
-            if "repos" in repo_group:
-                for repo_label, repo_url in repo_group["repos"].items():
-                    repos.append((repo_label, repo_url, None, cert_name, ca_cert, cert, key))
             # Repository list with product and content set information
-            if "products" in repo_group:
-                for product_id, product in repo_group["products"].items():
-                    product_id = int(product_id)
-                    products[product_id] = {"name": product["name"], "content_sets": {}}
-                    for content_set_label, content_set in product["content_sets"].items():
-                        products[product_id]["content_sets"][content_set_label] = content_set["name"]
-                        for repo_label, repo_url in content_set["repos"].items():
-                            repos.append((repo_label, repo_url, content_set_label, cert_name, ca_cert, cert, key))
+            for product_id, product in repo_group["products"].items():
+                product_id = int(product_id)
+                products[product_id] = {"name": product["name"], "content_sets": {}}
+                for content_set_label, content_set in product["content_sets"].items():
+                    products[product_id]["content_sets"][content_set_label] = content_set["name"]
+                    for repo_label, repo_url in content_set["repos"].items():
+                        repos.append((repo_label, repo_url, content_set_label, cert_name, ca_cert, cert, key))
 
         return products, repos
 

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -46,9 +46,9 @@ def repo_sync_task(products=None, repos=None):
         if repos:
             # Sync repos from input
             for repo in repos:
-                repo_label, repo_url, content_set, cert_name, ca_cert, cert, key = repo
-                repository_controller.add_repository(repo_label, repo_url, content_set=content_set,
-                                                     cert_name=cert_name, ca_cert=ca_cert, cert=cert, key=key)
+                repo_url, content_set, basearch, releasever, cert_name, ca_cert, cert, key = repo
+                repository_controller.add_repository(repo_url, content_set, basearch, releasever, cert_name=cert_name,
+                                                     ca_cert=ca_cert, cert=cert, key=key)
         else:
             # Re-sync repos in DB
             repository_controller.add_synced_repositories()

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -190,11 +190,10 @@ class RepoSyncHandler(SyncHandler):
                 cert_name, ca_cert, cert, key = None, None, None, None
 
             # Repository list with product and content set information
-            for product_id, product in repo_group["products"].items():
-                product_id = int(product_id)
-                products[product_id] = {"name": product["name"], "content_sets": {}}
+            for product_name, product in repo_group["products"].items():
+                products[product_name] = {"product_id": product.get("redhat_eng_product_id", None), "content_sets": {}}
                 for content_set_label, content_set in product["content_sets"].items():
-                    products[product_id]["content_sets"][content_set_label] = content_set["name"]
+                    products[product_name]["content_sets"][content_set_label] = content_set["name"]
                     for repo_label, repo_url in content_set["repos"].items():
                         repos.append((repo_label, repo_url, content_set_label, cert_name, ca_cert, cert, key))
 

--- a/reposcan/test_data/api/repolist.json
+++ b/reposcan/test_data/api/repolist.json
@@ -1,0 +1,82 @@
+[{
+  "entitlement_cert": {
+    "name": "RHSM-CDN",
+    "ca_cert": "<CA CERTIFICATE>",
+    "cert": "<CLIENT CERTIFICATE>",
+    "key": "<CLIENT KEY>"
+  },
+  "products": {
+    "Red Hat Enterprise Linux Server": {
+      "redhat_eng_product_id": 69,
+      "content_sets": {
+        "rhel-7-server-rpms": {
+          "name": "Red Hat Enterprise Linux 7 Server (RPMs)",
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["7Server", "7.4"]
+        },
+        "rhel-7-server-optional-rpms": {
+          "name": "Red Hat Enterprise Linux 7 Server - Optional (RPMs)",
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/optional/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["7Server", "7.4"]
+        },
+        "rhel-6-server-rpms": {
+          "name": "Red Hat Enterprise Linux 6 Server (RPMs)",
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/server/6/$releasever/$basearch/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["6Server", "6.9"]
+        },
+        "rhel-6-server-optional-rpms": {
+          "name": "Red Hat Enterprise Linux 6 Server - Optional (RPMs)",
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/server/6/$releasever/$basearch/optional/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["6Server", "6.9"]
+        }
+      }
+    },
+    "Red Hat Enterprise Linux Workstation": {
+      "redhat_eng_product_id": 71,
+      "content_sets": {
+        "rhel-7-workstation-rpms": {
+          "name": "Red Hat Enterprise Linux 7 Workstation (RPMs)",
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/workstation/7/$releasever/$basearch/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["7Workstation", "7.4"]
+        },
+        "rhel-7-workstation-optional-rpms": {
+          "name": "Red Hat Enterprise Linux 7 Workstation - Optional (RPMs)",
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/workstation/7/$releasever/$basearch/optional/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["7Workstation", "7.4"]
+        },
+        "rhel-6-workstation-rpms": {
+          "name": "Red Hat Enterprise Linux 6 Workstation (RPMs)",
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/workstation/6/$releasever/$basearch/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["6Workstation", "6.9"]
+        },
+        "rhel-6-workstation-optional-rpms": {
+          "name": "Red Hat Enterprise Linux 6 Workstation - Optional (RPMs)",
+          "baseurl": "https://cdn.redhat.com/content/dist/rhel/workstation/6/$releasever/$basearch/optional/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["6Workstation", "6.9"]
+        }
+      }
+    }
+  }
+},
+{
+  "products": {
+    "Fedora": {
+      "content_sets": {
+        "updates": {
+          "name": "Fedora Updates",
+          "baseurl": "https://mirrors.nic.cz/fedora/linux/updates/$releasever/$basearch/",
+          "basearch": ["x86_64"],
+          "releasever": ["27"]
+        }
+      }
+    }
+  }
+}]


### PR DESCRIPTION
Second piece to fix #142, this PR requires #158 to be merged first.

Note: input for reposcan API changed format:
```json
[{
  "entitlement_cert": {
    "name": "RHSM-CDN",
    "ca_cert": "<CA CERTIFICATE>",
    "cert": "<CLIENT CERTIFICATE>",
    "key": "<CLIENT KEY>"
  },
  "products": {
    "Red Hat Enterprise Linux Server": {
      "redhat_eng_product_id": 69,
      "content_sets": {
        "rhel-7-server-rpms": {
          "name": "Red Hat Enterprise Linux 7 Server (RPMs)",
          "baseurl": "https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/os/",
          "basearch": ["x86_64"],
          "releasever": ["7Server", "7.4"]
        },
        "rhel-7-server-optional-rpms": {
          "name": "Red Hat Enterprise Linux 7 Server - Optional (RPMs)",
          "baseurl": "https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/optional/os/",
          "basearch": ["x86_64"],
          "releasever": ["7Server", "7.4"]
        },
        "rhel-6-server-rpms": {
          "name": "Red Hat Enterprise Linux 6 Server (RPMs)",
          "baseurl": "https://cdn.redhat.com/content/dist/rhel/server/6/$releasever/$basearch/os/",
          "basearch": ["x86_64"],
          "releasever": ["6Server", "6.9"]
        },
        "rhel-6-server-optional-rpms": {
          "name": "Red Hat Enterprise Linux 6 Server - Optional (RPMs)",
          "baseurl": "https://cdn.redhat.com/content/dist/rhel/server/6/$releasever/$basearch/optional/os/",
          "basearch": ["x86_64"],
          "releasever": ["6Server", "6.9"]
        }
      }
    },
    "Red Hat Enterprise Linux Workstation": {
      "redhat_eng_product_id": 71,
      "content_sets": {
        "rhel-7-workstation-rpms": {
          "name": "Red Hat Enterprise Linux 7 Workstation (RPMs)",
          "baseurl": "https://cdn.redhat.com/content/dist/rhel/workstation/7/$releasever/$basearch/os/",
          "basearch": ["x86_64"],
          "releasever": ["7Workstation", "7.4"]
        },
        "rhel-7-workstation-optional-rpms": {
          "name": "Red Hat Enterprise Linux 7 Workstation - Optional (RPMs)",
          "baseurl": "https://cdn.redhat.com/content/dist/rhel/workstation/7/$releasever/$basearch/optional/os/",
          "basearch": ["x86_64"],
          "releasever": ["7Workstation", "7.4"]
        },
        "rhel-6-workstation-rpms": {
          "name": "Red Hat Enterprise Linux 6 Workstation (RPMs)",
          "baseurl": "https://cdn.redhat.com/content/dist/rhel/workstation/6/$releasever/$basearch/os/",
          "basearch": ["x86_64"],
          "releasever": ["6Workstation", "6.9"]
        },
        "rhel-6-workstation-optional-rpms": {
          "name": "Red Hat Enterprise Linux 6 Workstation - Optional (RPMs)",
          "baseurl": "https://cdn.redhat.com/content/dist/rhel/workstation/6/$releasever/$basearch/optional/os/",
          "basearch": ["x86_64"],
          "releasever": ["6Workstation", "6.9"]
        }
      }
    }
  }
},
{
  "products": {
    "Fedora": {
      "content_sets": {
        "updates": {
          "name": "Fedora Updates",
          "baseurl": "https://mirrors.nic.cz/fedora/linux/updates/$releasever/$basearch/",
          "basearch": ["x86_64"],
          "releasever": ["27"]
        }
      }
    }
  }
}]
```