### PR TITLE
166 - Teach reposcan to set Content-Type to app/json

### DIFF
--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -110,11 +110,12 @@ class SyncTask:
 class ResponseJson(dict): # pylint: disable=too-few-public-methods
     """Object used as API response to user, represented as JSON"""
     def __init__(self, msg, success=True):
+        super(ResponseJson, self).__init__()
         self['msg'] = msg
         self['success'] = success
 
     def __repr__(self):
-        return json.dumps({"success1": self.success, "msg2": self.msg})
+        return json.dumps({"success1": self['success'], "msg2": self['msg']})
 
 
 

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -115,8 +115,7 @@ class ResponseJson(dict): # pylint: disable=too-few-public-methods
         self['success'] = success
 
     def __repr__(self):
-        return json.dumps({"success1": self['success'], "msg2": self['msg']})
-
+        return json.dumps(self)
 
 
 class SyncHandler(RequestHandler):

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -222,6 +222,7 @@ class RepoSyncHandler(SyncHandler):
         status_code, status_msg = SyncHandler.start_task(self.task_type, repo_sync_task, self.on_complete, (), {})
         self.set_status(status_code)
         self.write(status_msg)
+        self.set_header('Content-Type', 'application/json')
         self.flush()
 
     def post(self, *args, **kwargs):
@@ -233,13 +234,16 @@ class RepoSyncHandler(SyncHandler):
             repos = None
             LOGGER.log(traceback.format_exc())
             self.set_status(400)
+
             self.write(str(ResponseMsg("Incorrect JSON format.", success=False)))
+            self.set_header('Content-Type', 'application/json')
             self.flush()
         if repos:
             status_code, status_msg = SyncHandler.start_task(self.task_type, repo_sync_task, self.on_complete, (),
                                                              {"products": products, "repos": repos})
             self.set_status(status_code)
             self.write(status_msg)
+            self.set_header('Content-Type', 'application/json')
             self.flush()
 
     @staticmethod
@@ -258,6 +262,7 @@ class CveSyncHandler(SyncHandler):
         status_code, status_msg = SyncHandler.start_task(self.task_type, cve_sync_task, self.on_complete, (), {})
         self.set_status(status_code)
         self.write(status_msg)
+        self.set_header('Content-Type', 'application/json')
         self.flush()
 
     @staticmethod
@@ -276,6 +281,7 @@ class AllSyncHandler(SyncHandler):
         status_code, status_msg = SyncHandler.start_task(self.task_type, all_sync_task, self.on_complete, (), {})
         self.set_status(status_code)
         self.write(status_msg)
+        self.set_header('Content-Type', 'application/json')
         self.flush()
 
     @staticmethod


### PR DESCRIPTION
There has to be a better/more-std/more-pythonic way to do this

tornado should auto-recognize write(dict) as Content-type app/json - what's the best way to make ResponseMsg return a dict instead of a string that just happens to look a lot like json?