### PR TITLE
improve timestamp handling

### DIFF
--- a/database/vmaas_db_postgresql.sql
+++ b/database/vmaas_db_postgresql.sql
@@ -290,8 +290,8 @@ CREATE TABLE IF NOT EXISTS errata (
   summary TEXT NOT NULL,
   description TEXT NOT NULL,
   solution TEXT,
-  issued TIMESTAMP NOT NULL,
-  updated TIMESTAMP NOT NULL,
+  issued TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated TIMESTAMP WITH TIME ZONE NOT NULL,
   PRIMARY KEY (id),
   CONSTRAINT severity_id
     FOREIGN KEY (severity_id)
@@ -342,8 +342,8 @@ CREATE TABLE IF NOT EXISTS cve (
   name TEXT NOT NULL UNIQUE,
   description TEXT NULL,
   severity_id INT,
-  published_date TIMESTAMP,
-  modified_date TIMESTAMP,
+  published_date TIMESTAMP WITH TIME ZONE NULL,
+  modified_date TIMESTAMP WITH TIME ZONE NULL,
   cvss3_score NUMERIC(5,3),
   iava TEXT,
   redhat_url TEXT,

--- a/reposcan/common/utc.py
+++ b/reposcan/common/utc.py
@@ -1,0 +1,20 @@
+"""
+Module containing implementation of tzinfo UTC object.
+"""
+from datetime import tzinfo, timedelta
+
+ZERO = timedelta(0)
+
+
+class UtcTz(tzinfo):
+    """UTC"""
+    def utcoffset(self, dt):
+        return ZERO
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return ZERO
+
+UTC = UtcTz()

--- a/reposcan/database/cve_store.py
+++ b/reposcan/database/cve_store.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from psycopg2.extras import execute_values
 
 from cli.logger import SimpleLogger
+from common.utc import UTC
 from database.database_handler import DatabaseHandler
 
 class CveStore:
@@ -100,8 +101,8 @@ class CveStore:
             cve_desc_list = _dget(cve, "cve", "description", "description_data")
             severity = _dget(cve, "impact", "baseMetricV3", "cvssV3", "baseSeverity")
             url_list = _dget(cve, "cve", "references", "reference_data")
-            modified_date = datetime.strptime(_dget(cve, "lastModifiedDate"), "%Y-%m-%dT%H:%MZ")
-            published_date = datetime.strptime(_dget(cve, "publishedDate"), "%Y-%m-%dT%H:%MZ")
+            modified_date = datetime.strptime(_dget(cve, "lastModifiedDate"), "%Y-%m-%dT%H:%MZ").replace(tzinfo=UTC)
+            published_date = datetime.strptime(_dget(cve, "publishedDate"), "%Y-%m-%dT%H:%MZ").replace(tzinfo=UTC)
             cwe_data = _dget(cve, "cve", "problemtype", "problemtype_data")
             cwe_list = _process_cwe_list(cwe_data)
             redhat_url, secondary_url = _process_url_list(cve_name, url_list)

--- a/reposcan/database/repository_store.py
+++ b/reposcan/database/repository_store.py
@@ -85,13 +85,13 @@ class RepositoryStore:
         if not repo_id:
             cur.execute("""insert into repo (url, content_set_id, basearch_id, releasever,
                                              revision, eol, certificate_id)
-                        values (%s, %s, %s, %s, to_timestamp(%s), false, %s) returning id""",
+                        values (%s, %s, %s, %s, %s, false, %s) returning id""",
                         (repo.repo_url, content_set_id, basearch_id, repo.releasever,
                          repo.repomd.get_revision(), cert_id,))
             repo_id = cur.fetchone()
         else:
             # Update repository timestamp
-            cur.execute("""update repo set revision = to_timestamp(%s), certificate_id = %s, content_set_id = %s,
+            cur.execute("""update repo set revision = %s, certificate_id = %s, content_set_id = %s,
                                            basearch_id = %s, releasever = %s
                         where id = %s""", (repo.repomd.get_revision(), cert_id, content_set_id, basearch_id,
                                            repo.releasever, repo_id[0],))

--- a/reposcan/repodata/repomd.py
+++ b/reposcan/repodata/repomd.py
@@ -1,7 +1,10 @@
 """
 Module containing class for Repo XML metadata.
 """
+from datetime import datetime
 import xml.etree.ElementTree as eT
+
+from common.utc import UTC
 
 NS = {"repo": "http://linux.duke.edu/metadata/repo"}
 
@@ -16,7 +19,7 @@ class RepoMD:
     def __init__(self, filename):
         tree = eT.parse(filename)
         root = tree.getroot()
-        self.revision = int(root.find("repo:revision", NS).text.strip())
+        self.revision = datetime.fromtimestamp(int(root.find("repo:revision", NS).text.strip()), tz=UTC)
         self.data = {}
         for child in root.findall("repo:data", NS):
             data_type = child.get("type")

--- a/reposcan/repodata/repository_controller.py
+++ b/reposcan/repodata/repository_controller.py
@@ -4,11 +4,11 @@ Module containing class for syncing set of repositories into the DB.
 import os
 import shutil
 import tempfile
-from datetime import datetime, timezone
 from urllib.parse import urljoin
 
 from cli.logger import SimpleLogger
 from common.batch_list import BatchList
+
 from database.repository_store import RepositoryStore
 from download.downloader import FileDownloader, DownloadItem, VALID_HTTP_CODES
 from download.unpacker import FileUnpacker
@@ -75,7 +75,7 @@ class RepositoryController:
                     db_revision = db_repositories[repository_key]["revision"]
                 else:
                     db_revision = None
-                downloaded_revision = datetime.fromtimestamp(repomd.get_revision(), tz=timezone.utc)
+                downloaded_revision = repomd.get_revision()
                 # Repository is synced for the first time or has newer revision
                 if db_revision is None or downloaded_revision > db_revision:
                     repository.repomd = repomd

--- a/reposcan/repodata/test/test_repomd.py
+++ b/reposcan/repodata/test/test_repomd.py
@@ -1,6 +1,7 @@
 """
 Unit test classes for repomd module.
 """
+from datetime import datetime
 import unittest
 from xml.etree.ElementTree import ParseError
 from repodata.repomd import RepoMD, RepoMDTypeNotFound
@@ -16,8 +17,8 @@ class TestRepoMD(unittest.TestCase):
 
     def test_revision(self):
         """Test getting revision timestamp."""
-        self.assertIsInstance(self.repomd.get_revision(), int)
-        self.assertIsInstance(self.repomd_primary_only.get_revision(), int)
+        self.assertIsInstance(self.repomd.get_revision(), datetime)
+        self.assertIsInstance(self.repomd_primary_only.get_revision(), datetime)
         self.assertEqual(self.repomd.get_revision(), self.repomd_primary_only.get_revision())
 
     def _test_repomd(self, data):

--- a/webapp/cve.py
+++ b/webapp/cve.py
@@ -2,6 +2,8 @@
 Module contains functions and CVE class for returning data from DB
 """
 
+from utils import format_datetime
+
 
 class CVE(object):
     """
@@ -103,8 +105,8 @@ class CveAPI(object):
                 "secondary_url": cve.get_val("secondary_url"),
                 "synopsis": cve.get_val("cve.name"),
                 "impact": cve.get_val("severity.name"),
-                "public_date": str(cve.get_val("published_date")),
-                "modified_date": str(cve.get_val("modified_date")),
+                "public_date": format_datetime(cve.get_val("published_date")),
+                "modified_date": format_datetime(cve.get_val("modified_date")),
                 "cwe_list": cve.get_val("cwe"),
                 "cvss3_score": str(cve.get_val("cvss3_score")),
                 "description": cve.get_val("description"),

--- a/webapp/errata.py
+++ b/webapp/errata.py
@@ -2,7 +2,8 @@
 Module contains classes for returning errata data from DB
 """
 
-from utils import join_packagename
+from utils import format_datetime, join_packagename
+
 
 class Errata(object):
     """
@@ -15,13 +16,13 @@ class Errata(object):
         self.oid = oid
         self.data = {
             "type": errata_type,
-            "issued": str(issued),
+            "issued": format_datetime(issued),
             "synopsis": synopsis,
             "description": description,
             "solution": solution,
             "severity": severity,
             "summary": summary,
-            "updated": str(updated),
+            "updated": format_datetime(updated),
             "url": "https://access.redhat.com/errata/%s" % name,
             "bugzilla_list": [],
             "cve_list": [],

--- a/webapp/repos.py
+++ b/webapp/repos.py
@@ -27,14 +27,15 @@ class RepoCache(object):
                                       r.url,
                                       a.name as basearch_name,
                                       r.releasever,
-                                      p.name as product_name
+                                      p.name as product_name,
+                                      r.revision
                                  FROM repo r
                                  JOIN content_set cs ON cs.id = r.content_set_id
                                  JOIN arch a ON a.id = r.basearch_id
                                  JOIN product p ON p.id = cs.product_id
                                  """)
 
-        for oid, label, name, url, basearch, releasever, product in self.cursor.fetchall():
+        for oid, label, name, url, basearch, releasever, product, revision in self.cursor.fetchall():
             repo_obj = RepoDict(oid, {
                 "label": label,
                 "name": name,
@@ -42,6 +43,7 @@ class RepoCache(object):
                 "basearch": basearch,
                 "releasever": releasever,
                 "product": product,
+                "revision": str(revision),
                 })
             self.cache_id[oid] = repo_obj
             self.cache_label[label] = repo_obj

--- a/webapp/repos.py
+++ b/webapp/repos.py
@@ -2,7 +2,8 @@
 Module to handle /repos API calls.
 """
 
-from utils import ListDict
+from utils import ListDict, format_datetime
+
 
 class RepoDict(dict):
     """Dictionary to hold repository data, the extra id attribute
@@ -43,7 +44,7 @@ class RepoCache(object):
                 "basearch": basearch,
                 "releasever": releasever,
                 "product": product,
-                "revision": str(revision),
+                "revision": format_datetime(revision),
                 })
             self.cache_id[oid] = repo_obj
             self.cache_label[label] = repo_obj

--- a/webapp/utils.py
+++ b/webapp/utils.py
@@ -2,6 +2,7 @@
 Set of functions and precedures shared between different modules.
 """
 
+from datetime import datetime
 import re
 
 def join_packagename(name, epoch, version, release, arch):
@@ -31,6 +32,14 @@ def split_packagename(filename):
     name, _, epoch, version, release, arch = match.groups()
     epoch = int(epoch) if epoch is not None else 0
     return name, epoch, version, release, arch
+
+
+def format_datetime(datetime_obj):
+    """Try to format object to ISO 8601 if object is datetime."""
+    if isinstance(datetime_obj, datetime):
+        return datetime_obj.isoformat()
+    return str(datetime_obj)
+
 
 class ListDict(dict):
     """Dictionary which can cummulate multiple values for the same key into a list."""


### PR DESCRIPTION
fixes #116 

- all timestamps in DB to use timezones
- enhance repo API to return revision
- import all timestamps (from repodata, CVE lists) as UTC timestamps regardless of DB timezone
- output format in ISO 8601