### PR TITLE
Interactive Swagger UI API doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ wheels/
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 notifications:
   email: false
 install:
-  - pip install pylint psycopg2 requests tornado
+  - pip install pylint psycopg2 requests tornado apispec
 script:
   - /bin/bash run_tests.sh reposcan
   - /bin/bash run_tests.sh webapp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,18 @@ services:
     depends_on:
       - database
 
+  apidoc:
+    container_name: vmaas-apidoc
+    image: swaggerapi/swagger-ui:v3.13.2
+    restart: unless-stopped
+    environment:
+      - API_URLS=[{url:'http://localhost:8080/api/v1/apispec', name:'webapp'},{url:'http://localhost:8081/api/v1/apispec', name:'reposcan'}]
+    ports:
+      - 8000:8080
+    depends_on:
+      - reposcan
+      - webapp
+
 volumes:
   vmaas-db-data:
   vmaas-reposcan-tmp:

--- a/libs/python-apispec/python-apispec.spec
+++ b/libs/python-apispec/python-apispec.spec
@@ -1,0 +1,81 @@
+%global pypi_name apispec
+
+%if 0%{?fedora} || 0%{?rhel} >= 8
+%global build_py3   1
+%endif
+
+Name:           python-%{pypi_name}
+Version:        0.33.0
+Release:        1%{?dist}
+Summary:        A pluggable API specification generator. Currently supports the OpenAPI specification (f.k.a. Swagger 2.0)
+
+License:        MIT
+URL:            https://github.com/marshmallow-code/apispec
+Source0:        https://files.pythonhosted.org/packages/source/a/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+ 
+BuildRequires:  python2-devel
+BuildRequires:  python-setuptools
+
+%if 0%{?build_py3}
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+%endif
+
+%description
+apispec is a pluggable API specification generator. Currently supports the OpenAPI specification (f.k.a. Swagger 2.0). Includes plugins for marshmallow, Flask, Tornado and bottle.
+
+%package -n     python2-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{pypi_name}}
+Requires:       PyYAML >= 3.10
+%description -n python2-%{pypi_name}
+apispec is a pluggable API specification generator. Currently supports the OpenAPI specification (f.k.a. Swagger 2.0). Includes plugins for marshmallow, Flask, Tornado and bottle.
+
+%if 0%{?build_py3}
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+Requires:       python3-PyYAML >= 3.10
+%description -n python3-%{pypi_name}
+apispec is a pluggable API specification generator. Currently supports the OpenAPI specification (f.k.a. Swagger 2.0). Includes plugins for marshmallow, Flask, Tornado and bottle.
+%endif
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+%if 0%{?build_py3}
+%py3_build
+%endif
+
+%install
+# Must do the subpackages' install first because the scripts in /usr/bin are
+# overwritten with every setup.py install.
+%if 0%{?build_py3}
+%py3_install
+%endif
+%py2_install
+
+%check
+
+%files -n python2-%{pypi_name}
+%license docs/license.rst LICENSE
+%doc README.rst
+%{python2_sitelib}/%{pypi_name}
+%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+%if 0%{?build_py3}
+%files -n python3-%{pypi_name}
+%license docs/license.rst LICENSE
+%doc README.rst
+%{python3_sitelib}/%{pypi_name}
+%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%endif
+
+%changelog
+* Fri Mar 30 2018 Jan Dobes <jdobes@redhat.com> - 0.33.0-1
+- Initial package.

--- a/reposcan/Dockerfile
+++ b/reposcan/Dockerfile
@@ -10,9 +10,10 @@ ENV WEBAPP_API_URL=http://webapp
 ENV WEBAPP_API_PORT_INTERNAL=8079
 ENV REPOSCAN_SYNC_INTERVAL_MINUTES=720
 
-RUN yum install -y python3-psycopg2 python3-requests \
-                   python3-tornado postgresql-libs postgresql \
-    && rm -rf /var/cache/yum/*
+RUN dnf install -y dnf-plugins-core && dnf copr enable -y jdobes/vmaas-libs \
+    && dnf install -y python3-apispec python3-psycopg2 python3-requests \
+                      python3-tornado postgresql-libs postgresql \
+    && rm -rf /var/cache/dnf/*
 
 # copy application to directory in a container
 ADD . /vmaas-reposcan/

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -134,7 +134,7 @@ class ApiSpecHandler(RequestHandler):
         """Handles streamed data."""
         pass
 
-    def get(self):
+    def get(self): # pylint: disable=arguments-differ
         """Get API specification.
            ---
            description: Get API specification
@@ -246,7 +246,7 @@ class RepoSyncHandler(SyncHandler):
 
         return products, repos
 
-    def get(self):
+    def get(self): # pylint: disable=arguments-differ
         """Sync repositories stored in DB.
            ---
            description: Sync repositories stored in DB
@@ -261,7 +261,7 @@ class RepoSyncHandler(SyncHandler):
         self.write(status_msg)
         self.flush()
 
-    def post(self):
+    def post(self): # pylint: disable=arguments-differ
         """Sync repositories listed in request.
            ---
            description: Sync repositories listed in request
@@ -301,7 +301,7 @@ class CveSyncHandler(SyncHandler):
 
     task_type = "CVE"
 
-    def get(self):
+    def get(self): # pylint: disable=arguments-differ
         """Sync CVEs.
            ---
            description: Sync CVE lists
@@ -327,7 +327,7 @@ class AllSyncHandler(SyncHandler):
 
     task_type = "%s + %s" % (RepoSyncHandler.task_type, CveSyncHandler.task_type)
 
-    def get(self):
+    def get(self): # pylint: disable=arguments-differ
         """Sync repos + CVEs.
            ---
            description: Sync repositories stored in DB and CVE lists

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -134,8 +134,14 @@ class ApiSpecHandler(RequestHandler):
         """Handles streamed data."""
         pass
 
-    def get(self, *args, **kwargs):
-        """Get Apispec."""
+    def get(self):
+        """Get API specification.
+           ---
+           description: Get API specification
+           responses:
+             200:
+               description: OpenAPI/Swagger 2.0 specification JSON returned
+        """
         self.set_header("Access-Control-Allow-Origin", "*")
         self.write(SPEC.to_dict())
 
@@ -240,15 +246,33 @@ class RepoSyncHandler(SyncHandler):
 
         return products, repos
 
-    def get(self, *args, **kwargs):
-        """Sync repositories stored in DB."""
+    def get(self):
+        """Sync repositories stored in DB.
+           ---
+           description: Sync repositories stored in DB
+           responses:
+             200:
+               description: Sync started
+             429:
+               description: Another sync is already in progress
+        """
         status_code, status_msg = SyncHandler.start_task(self.task_type, repo_sync_task, self.on_complete, (), {})
         self.set_status(status_code)
         self.write(status_msg)
         self.flush()
 
-    def post(self, *args, **kwargs):
-        """Sync repositories listed in request."""
+    def post(self):
+        """Sync repositories listed in request.
+           ---
+           description: Sync repositories listed in request
+           responses:
+             200:
+               description: Sync started
+             400:
+               description: Invalid input JSON format
+             429:
+               description: Another sync is already in progress
+        """
         try:
             products, repos = self._parse_input_list()
         except: # pylint: disable=bare-except
@@ -277,8 +301,16 @@ class CveSyncHandler(SyncHandler):
 
     task_type = "CVE"
 
-    def get(self, *args, **kwargs):
-        """Sync CVEs."""
+    def get(self):
+        """Sync CVEs.
+           ---
+           description: Sync CVE lists
+           responses:
+             200:
+               description: Sync started
+             429:
+               description: Another sync is already in progress
+        """
         status_code, status_msg = SyncHandler.start_task(self.task_type, cve_sync_task, self.on_complete, (), {})
         self.set_status(status_code)
         self.write(status_msg)
@@ -295,8 +327,16 @@ class AllSyncHandler(SyncHandler):
 
     task_type = "%s + %s" % (RepoSyncHandler.task_type, CveSyncHandler.task_type)
 
-    def get(self, *args, **kwargs):
-        """Sync repos + CVEs."""
+    def get(self):
+        """Sync repos + CVEs.
+           ---
+           description: Sync repositories stored in DB and CVE lists
+           responses:
+             200:
+               description: Sync started
+             429:
+               description: Another sync is already in progress
+        """
         status_code, status_msg = SyncHandler.start_task(self.task_type, all_sync_task, self.on_complete, (), {})
         self.set_status(status_code)
         self.write(status_msg)

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -8,7 +8,7 @@ ENV POSTGRESQL_USER=vmaas_user
 ENV POSTGRESQL_PASSWORD=vmaas_passwd
 ENV POSTGRESQL_DATABASE=vmaas
 
-RUN yum -y update && yum -y install python-tornado python-psycopg2 postgresql && rm -rf /var/cache/yum/*
+RUN yum -y update && yum -y install yum-plugin-copr && yum -y copr enable jdobes/vmaas-libs && yum -y install python-tornado python-psycopg2 python2-apispec postgresql && rm -rf /var/cache/yum/*
 
 ADD ./wait-for-postgres.sh /app/wait-for-postgres.sh
 ADD ./entrypoint.sh /app/

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -33,7 +33,7 @@ SPEC = APISpec(
 # pylint: disable=abstract-method
 class ApiSpecHandler(tornado.web.RequestHandler):
     """Handler class providing API specification."""
-    def get(self):
+    def get(self): # pylint: disable=arguments-differ
         """Get API specification.
            ---
            description: Get API specification
@@ -50,7 +50,7 @@ class RefreshHandler(tornado.web.RequestHandler):
     """
     Class to refresh cached data in handlers.
     """
-    def get(self, *args, **kwargs):
+    def get(self): # pylint: disable=arguments-differ
         # There could be authentication instead of this simple check in future
         accessed_port = int(self.request.host.split(':')[1])
         if accessed_port == INTERNAL_API_PORT:
@@ -76,6 +76,7 @@ class JsonHandler(tornado.web.RequestHandler):
     Parent class to parse input json data given a a data or a file.
     """
     def process_get(self):
+        """Process GET request."""
         index = self.request.uri.rfind('/')
         name = self.request.uri[index + 1:]
 
@@ -84,6 +85,7 @@ class JsonHandler(tornado.web.RequestHandler):
         self.flush()
 
     def process_post(self):
+        """Process POST request."""
         # extract input JSON from POST request
         json_data = ''
         # check if JSON is passed as a file or as a body of POST request
@@ -121,7 +123,8 @@ class UpdatesHandler(JsonHandler):
 
 
 class UpdatesHandlerGet(UpdatesHandler):
-    def get(self):
+    """Handler for processing /updates GET requests."""
+    def get(self): # pylint: disable=arguments-differ
         """
         ---
         description: List security updates for single package NEVRA
@@ -133,7 +136,8 @@ class UpdatesHandlerGet(UpdatesHandler):
 
 
 class UpdatesHandlerPost(UpdatesHandler):
-    def post(self):
+    """Handler for processing /updates POST requests."""
+    def post(self): # pylint: disable=arguments-differ
         """
         ---
         description: List security updates for list of package NEVRAs
@@ -156,7 +160,8 @@ class CVEHandler(JsonHandler):
 
 
 class CVEHandlerGet(CVEHandler):
-    def get(self):
+    """Handler for processing /cves GET requests."""
+    def get(self): # pylint: disable=arguments-differ
         """
         ---
         description: Get details about single CVE
@@ -168,7 +173,8 @@ class CVEHandlerGet(CVEHandler):
 
 
 class CVEHandlerPost(CVEHandler):
-    def post(self):
+    """Handler for processing /cves POST requests."""
+    def post(self): # pylint: disable=arguments-differ
         """
         ---
         description: Get details about list of CVEs
@@ -191,7 +197,8 @@ class ReposHandler(JsonHandler):
 
 
 class ReposHandlerGet(ReposHandler):
-    def get(self):
+    """Handler for processing /repos GET requests."""
+    def get(self): # pylint: disable=arguments-differ
         """
         ---
         description: Get details about single repository
@@ -203,7 +210,8 @@ class ReposHandlerGet(ReposHandler):
 
 
 class ReposHandlerPost(ReposHandler):
-    def post(self):
+    """Handler for processing /repos POST requests."""
+    def post(self): # pylint: disable=arguments-differ
         """
         ---
         description: Get details about list of repositories
@@ -226,7 +234,8 @@ class ErrataHandler(JsonHandler):
 
 
 class ErrataHandlerGet(ErrataHandler):
-    def get(self):
+    """Handler for processing /errata GET requests."""
+    def get(self): # pylint: disable=arguments-differ
         """
         ---
         description: Get details about single erratum
@@ -238,7 +247,8 @@ class ErrataHandlerGet(ErrataHandler):
 
 
 class ErrataHandlerPost(ErrataHandler):
-    def post(self):
+    """Handler for processing /errata POST requests."""
+    def post(self): # pylint: disable=arguments-differ
         """
         ---
         description: Get details about list of errata

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -119,6 +119,8 @@ class UpdatesHandler(JsonHandler):
     def process_list(self, data):
         return self.application.updatesapi.process_list(data)
 
+
+class UpdatesHandlerGet(UpdatesHandler):
     def get(self):
         """
         ---
@@ -129,6 +131,8 @@ class UpdatesHandler(JsonHandler):
         """
         self.process_get()
 
+
+class UpdatesHandlerPost(UpdatesHandler):
     def post(self):
         """
         ---
@@ -150,6 +154,8 @@ class CVEHandler(JsonHandler):
     def process_list(self, data):
         return self.application.cveapi.process_list(data)
 
+
+class CVEHandlerGet(CVEHandler):
     def get(self):
         """
         ---
@@ -160,6 +166,8 @@ class CVEHandler(JsonHandler):
         """
         self.process_get()
 
+
+class CVEHandlerPost(CVEHandler):
     def post(self):
         """
         ---
@@ -181,6 +189,8 @@ class ReposHandler(JsonHandler):
     def process_list(self, data):
         return self.application.repoapi.process_list(data)
 
+
+class ReposHandlerGet(ReposHandler):
     def get(self):
         """
         ---
@@ -191,6 +201,8 @@ class ReposHandler(JsonHandler):
         """
         self.process_get()
 
+
+class ReposHandlerPost(ReposHandler):
     def post(self):
         """
         ---
@@ -212,6 +224,8 @@ class ErrataHandler(JsonHandler):
     def process_list(self, data):
         return self.application.errataapi.process_list(data)
 
+
+class ErrataHandlerGet(ErrataHandler):
     def get(self):
         """
         ---
@@ -222,6 +236,8 @@ class ErrataHandler(JsonHandler):
         """
         self.process_get()
 
+
+class ErrataHandlerPost(ErrataHandler):
     def post(self):
         """
         ---
@@ -241,14 +257,14 @@ class Application(tornado.web.Application):
         handlers = [
             (r"/api/internal/refresh/?", RefreshHandler),  # GET request
             (r"/api/v1/apispec/?", ApiSpecHandler),
-            (r"/api/v1/updates/?", UpdatesHandler),  # POST request
-            (r"/api/v1/updates/[a-zA-Z0-9-._:]+", UpdatesHandler),  # GET request with package name
-            (r"/api/v1/cves/?", CVEHandler),
-            (r"/api/v1/cves/[a-zA-Z0-9*-]+", CVEHandler),
-            (r"/api/v1/repos/?", ReposHandler),
-            (r"/api/v1/repos/[a-zA-Z0-9*-_]+", ReposHandler),
-            (r"/api/v1/errata/?", ErrataHandler),  # POST request
-            (r"/api/v1/errata/[a-zA-Z0-9*-:]+", ErrataHandler) # GET request
+            (r"/api/v1/updates/?", UpdatesHandlerPost),
+            (r"/api/v1/updates/[a-zA-Z0-9-._:]+", UpdatesHandlerGet),
+            (r"/api/v1/cves/?", CVEHandlerPost),
+            (r"/api/v1/cves/[a-zA-Z0-9*-]+", CVEHandlerGet),
+            (r"/api/v1/repos/?", ReposHandlerPost),
+            (r"/api/v1/repos/[a-zA-Z0-9*-_]+", ReposHandlerGet),
+            (r"/api/v1/errata/?", ErrataHandlerPost),
+            (r"/api/v1/errata/[a-zA-Z0-9*-:]+", ErrataHandlerGet)
         ]
         # Register public API handlers to apispec
         for handler in handlers:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -75,7 +75,7 @@ class JsonHandler(tornado.web.RequestHandler):
     """
     Parent class to parse input json data given a a data or a file.
     """
-    def get(self, *args, **kwargs):
+    def process_get(self):
         index = self.request.uri.rfind('/')
         name = self.request.uri[index + 1:]
 
@@ -83,7 +83,7 @@ class JsonHandler(tornado.web.RequestHandler):
         self.write(response)
         self.flush()
 
-    def post(self, *args, **kwargs):
+    def process_post(self):
         # extract input JSON from POST request
         json_data = ''
         # check if JSON is passed as a file or as a body of POST request
@@ -110,6 +110,7 @@ class JsonHandler(tornado.web.RequestHandler):
         """ Method to process a single input data. """
         raise NotImplementedError("abstract method")
 
+
 class UpdatesHandler(JsonHandler):
     """ /updates API handler """
     def process_string(self, data):
@@ -117,6 +118,29 @@ class UpdatesHandler(JsonHandler):
 
     def process_list(self, data):
         return self.application.updatesapi.process_list(data)
+
+    def get(self):
+        """
+        ---
+        description: List security updates for single package NEVRA
+        responses:
+          200:
+            description: Return list of security updates for single package NEVRA
+        """
+        self.process_get()
+
+    def post(self):
+        """
+        ---
+        description: List security updates for list of package NEVRAs
+        responses:
+          200:
+            description: Return list of security updates for list of package NEVRAs
+          400:
+            description: Invalid input JSON format
+        """
+        self.process_post()
+
 
 class CVEHandler(JsonHandler):
     """ /cves API handler """
@@ -126,6 +150,29 @@ class CVEHandler(JsonHandler):
     def process_list(self, data):
         return self.application.cveapi.process_list(data)
 
+    def get(self):
+        """
+        ---
+        description: Get details about single CVE
+        responses:
+          200:
+            description: Return details about single CVE
+        """
+        self.process_get()
+
+    def post(self):
+        """
+        ---
+        description: Get details about list of CVEs
+        responses:
+          200:
+            description: Return details about list of CVEs
+          400:
+            description: Invalid input JSON format
+        """
+        self.process_post()
+
+
 class ReposHandler(JsonHandler):
     """ /repos API handler """
     def process_string(self, data):
@@ -134,6 +181,29 @@ class ReposHandler(JsonHandler):
     def process_list(self, data):
         return self.application.repoapi.process_list(data)
 
+    def get(self):
+        """
+        ---
+        description: Get details about single repository
+        responses:
+          200:
+            description: Return details about single repository
+        """
+        self.process_get()
+
+    def post(self):
+        """
+        ---
+        description: Get details about list of repositories
+        responses:
+          200:
+            description: Return details about list of repositories
+          400:
+            description: Invalid input JSON format
+        """
+        self.process_post()
+
+
 class ErrataHandler(JsonHandler):
     """ /errata API handler """
     def process_string(self, data):
@@ -141,6 +211,28 @@ class ErrataHandler(JsonHandler):
 
     def process_list(self, data):
         return self.application.errataapi.process_list(data)
+
+    def get(self):
+        """
+        ---
+        description: Get details about single erratum
+        responses:
+          200:
+            description: Return details about single erratum
+        """
+        self.process_get()
+
+    def post(self):
+        """
+        ---
+        description: Get details about list of errata
+        responses:
+          200:
+            description: Return details about list of errata
+          400:
+            description: Invalid input JSON format
+        """
+        self.process_post()
 
 
 class Application(tornado.web.Application):


### PR DESCRIPTION
This PR adds automatically generated API documentation (based on Python docstrings) visualized in Swagger UI (new service in docker-compose on port 8000).

Swagger UI is set up to visualize both webapp and reposcan APIs - Swagger UI fetches and displays JSON from newly added `/api/v1/apispec` APIs in both webapp and reposcan.

This JSON is in OpenAPI format and I used `apispec` Python library to generate it. Unfortunately, this library is not available in RHEL/CentOS/Fedora repositories (I was not able to find any similar library even) but I was able to build it in Copr using attached specfile (in jdobes/vmaas-libs repo, let's change it later).

TODO:
- add input and output JSON examples for each API
- find a way how to deploy in Openshift without manual config changes

![screenshot from 2018-04-02 17-19-38](https://user-images.githubusercontent.com/6650196/38202604-99136dd8-369c-11e8-98f1-9d215eca8702.png)
![screenshot from 2018-04-02 17-20-41](https://user-images.githubusercontent.com/6650196/38202611-9da0db88-369c-11e8-9e21-48621b694b8c.png)
![screenshot from 2018-04-02 17-21-05](https://user-images.githubusercontent.com/6650196/38202613-a02007da-369c-11e8-9e7f-693a20f4d7f0.png)
