### PR TITLE
Refactor to prevent pylint warnings in errata api

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -132,12 +132,13 @@ class Application(tornado.web.Application):
             (r"/api/v1/errata/?", ErrataHandler),  # POST request
             (r"/api/v1/errata/[a-zA-Z0-9*-:]+", ErrataHandler) # GET request
         ]
-        cursor = Database().cursor()
+        db = Database()
+        cursor = db.cursor()
         self.repocache = RepoCache(cursor)
         self.updatesapi = UpdatesAPI(cursor, self.repocache)
         self.cveapi = CveAPI(cursor)
         self.repoapi = RepoAPI(self.repocache)
-        self.errataapi = ErrataAPI(cursor)
+        self.errataapi = ErrataAPI(db)
         tornado.web.Application.__init__(self, handlers)
 
 

--- a/webapp/database.py
+++ b/webapp/database.py
@@ -3,6 +3,7 @@ Module to handle database connections.
 """
 import os
 import psycopg2
+import psycopg2.extras
 
 def _set_val(value, envname, default):
     return value if value is not None else os.getenv(envname, default)
@@ -34,3 +35,9 @@ class Database(object):
     def cursor(self):
         """ Returns cursor object connected to the database."""
         return self.connection.cursor()
+
+    def dictcursor(self):
+        """
+        Returns cursor object connected to the database that returns dictionary.
+        """
+        return self.connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)

--- a/webapp/errata.py
+++ b/webapp/errata.py
@@ -5,72 +5,37 @@ Module contains classes for returning errata data from DB
 from utils import format_datetime, join_packagename
 
 
-class Errata(object):
-    """
-    Class to hold Erratum attributes
-    """
-
-    def __init__(self, oid, name, synopsis, summary, errata_type, severity, description, solution, issued, updated):
-        #pylint: disable=too-many-arguments
-        self.name = name
-        self.oid = oid
-        self.data = {
-            "type": errata_type,
-            "issued": format_datetime(issued),
-            "synopsis": synopsis,
-            "description": description,
-            "solution": solution,
-            "severity": severity,
-            "summary": summary,
-            "updated": format_datetime(updated),
-            "url": "https://access.redhat.com/errata/%s" % name,
-            "bugzilla_list": [],
-            "cve_list": [],
-            "package_list": [],
-            "reference_list": [],
-        }
-
-    def add_cve(self, cve):
-        """ Put CVE into cve_list. """
-        self.data["cve_list"].append(cve)
-
-    def add_package(self, package):
-        """ Put package into package_list. """
-        self.data["package_list"].append(package)
-
-    def add_bugzilla(self, bugzilla):
-        """Put bugzilla into bugzilla_list. """
-        self.data["bugzilla_list"].append(bugzilla)
-
-    def add_reference(self, reference):
-        """Put reference into reference_list. """
-        self.data["reference_list"].append(reference)
-
-
 class ErrataAPI(object):
     """ Main /errata API class. """
-    def __init__(self, cursor):
-        self.cursor = cursor
+    def __init__(self, database):
+        self.cursor = database.dictcursor()
 
     def set_cves_for_errata(self, errata_map):
         """
         Populate the errata in the given errata_map with each erratum's
         list of cves.
         """
-        cve_query = """SELECT errata_cve.errata_id, cve.name FROM cve
+        cve_query = """SELECT errata_cve.errata_id as erratum_id,
+                              cve.name as cve_name
+                         FROM cve
                          JOIN errata_cve ON cve_id = cve.id
                         WHERE errata_cve.errata_id IN %s"""
         self.cursor.execute(cve_query, [tuple(errata_map.keys())])
         results = self.cursor.fetchall()
-        for erratum_id, cve_name in results:
-            errata_map[erratum_id].add_cve(cve_name)
+        for result in results:
+            errata_map[result['erratum_id']]['cve_list'].append(result['cve_name'])
 
     def set_packages_for_errata(self, errata_map):
         """
         Populate the errata in the given errata_map with each erratum's
         list of packages.
         """
-        pkg_query = """SELECT pkg_errata.errata_id, package.name, evr.epoch, evr.version, evr.release, arch.name
+        pkg_query = """SELECT pkg_errata.errata_id as erratum_id,
+                              package.name as name,
+                              evr.epoch as epoch,
+                              evr.version as version,
+                              evr.release as release,
+                              arch.name as arch
                          FROM pkg_errata
                          JOIN package ON package.id = pkg_errata.pkg_id
                          JOIN evr ON evr.id = package.evr_id
@@ -78,30 +43,36 @@ class ErrataAPI(object):
                         WHERE pkg_errata.errata_id IN %s"""
         self.cursor.execute(pkg_query, [tuple(errata_map.keys())])
         results = self.cursor.fetchall()
-        for erratum_id, name, epoch, version, release, arch in results:
-            errata_map[erratum_id].add_package(join_packagename(name, epoch, version, release, arch))
+        for result in results:
+            packagename = join_packagename(result['name'],
+                                           result['epoch'],
+                                           result['version'],
+                                           result['release'],
+                                           result['arch'])
+            errata_map[result['erratum_id']]['package_list'].append(packagename)
 
     def set_references_for_errata(self, errata_map):
         """
         Populate the errata in the given errata_map with each erratum's
         list of references (bugzilla and other).
         """
-        refs_query = """SELECT errata_id, type, name FROM errata_refs
-                        WHERE errata_id IN %s"""
+        refs_query = """SELECT errata_id as erratum_id,
+                               type as ref_type,
+                               name
+                          FROM errata_refs
+                         WHERE errata_id IN %s"""
         self.cursor.execute(refs_query, [tuple(errata_map.keys())])
         results = self.cursor.fetchall()
-        for erratum_id, ref_type, name in results:
-            if ref_type == 'bugzilla':
-                errata_map[erratum_id].add_bugzilla(name)
+        for result in results:
+            if result['ref_type'] == 'bugzilla':
+                errata_map[result['erratum_id']]['bugzilla_list'].append(result['name'])
             else:
-                errata_map[erratum_id].add_reference(name)
+                errata_map[result['erratum_id']]['reference_list'].append(result['name'])
 
     def process_list(self, data):
-        #pylint: disable=too-many-locals
         """
         This method returns details for given set of Errata.
 
-        :param cursor: psycopg2 connection cursor
         :param data: data obtained from api, we're interested in data["errata_list"]
 
         :returns: dictionary containing detailed information for given errata list}
@@ -116,29 +87,41 @@ class ErrataAPI(object):
             return answer
 
         # Select all errata in request
-        errata_query = """SELECT errata.id, errata.name, synopsis, summary, errata_type.name,
-                                 severity.name, description, solution, issued, updated
+        errata_query = """SELECT errata.id as oid,
+                                 errata.name as name,
+                                 synopsis,
+                                 summary,
+                                 errata_type.name as type,
+                                 severity.name as severity,
+                                 description,
+                                 solution,
+                                 issued,
+                                 updated
                             FROM errata
                             JOIN errata_type ON errata_type_id = errata_type.id
                             JOIN severity ON severity_id = severity.id
                            WHERE errata.name IN %s"""
         self.cursor.execute(errata_query, [tuple(errata_to_process)])
-        errata = self.cursor.fetchall()
+        errata_results = self.cursor.fetchall()
 
-        errata_map = {}
-        for (oid, name, synopsis, summary, errata_type, severity,
-             description, solution, issued, updated) in errata:
-            new_erratum = Errata(oid, name, synopsis, summary, errata_type,
-                                 severity, description, solution, issued, updated)
-            errata_map[oid] = new_erratum
+        errata_map = {} # map keyed on oid for populating lists in errata
+        response_dict = {} # map keyed on erratum name to return to caller
+        for erratum in errata_results:
+            oid = erratum.pop('oid')
+            erratum_name = erratum.pop('name')
+            erratum['updated'] = format_datetime(erratum['updated'])
+            erratum['issued'] = format_datetime(erratum['issued'])
+            erratum['bugzilla_list'] = []
+            erratum['package_list'] = []
+            erratum['reference_list'] = []
+            erratum['cve_list'] = []
+            erratum['url'] = "https://access.redhat.com/errata/%s" % erratum_name
+            errata_map[oid] = erratum
+            response_dict[erratum_name] = erratum
 
         if errata_map:
             self.set_cves_for_errata(errata_map)
             self.set_packages_for_errata(errata_map)
             self.set_references_for_errata(errata_map)
 
-        response_dict = {}
-        for erratum in errata_map.values():
-            response_dict[erratum.name] = erratum.data
-        #answer["errata_list"] = response_dict
         return {"errata_list": response_dict}


### PR DESCRIPTION
This PR addresses Issue #120 for the errata api - it gets rid of the need to disable pylint warnings for too-many-arguments and too-many-local-variables.

This also changes errata api to use RealDictCursor from the psychopg2.extras package.  This allows us to use the dictionaries returned directly from the sql queries in the api response.  Take a look and see if we want to apply this across all APIs as it may be a slight performance increase in addition to removing the need to disable pylint warnings for too-many-arguments and too-many-local-variables.