### PR TITLE
Fix #209 - Check published as well as modified, if modified-since is …

### DIFF
--- a/webapp/cve.py
+++ b/webapp/cve.py
@@ -66,7 +66,8 @@ class CveAPI(object):
                         WHERE cve.name IN %s""".format(columns=', '.join(column_names))
         cve_query_params = [tuple(cves_to_process)]
         if modified_since:
-            cve_query += " and cve.modified_date >= %s"
+            cve_query += " and (cve.modified_date >= %s or cve.published_date >= %s)"
+            cve_query_params.append(parse_datetime(modified_since))
             cve_query_params.append(parse_datetime(modified_since))
         self.cursor.execute(cve_query, cve_query_params)
         cves = self.cursor.fetchall()


### PR DESCRIPTION
…present

NOTE: this still interprets "no date" as "never changed"; if both fields are
null, the CVE continues to be filtered out by modified-since