### PR TITLE
Fix #206 - get impact/severity from baseMetricV2 if V3 doesn't exist

### DIFF
--- a/reposcan/database/cve_store.py
+++ b/reposcan/database/cve_store.py
@@ -87,6 +87,8 @@ class CveStore:
 
             cve_desc_list = _dget(cve, "cve", "description", "description_data")
             impact = _dget(cve, "impact", "baseMetricV3", "cvssV3", "baseSeverity")
+            if impact is None:
+                impact = _dget(cve, "impact", "baseMetricV2", "severity")
             url_list = _dget(cve, "cve", "references", "reference_data")
             modified_date = parse_datetime(_dget(cve, "lastModifiedDate"))
             published_date = parse_datetime(_dget(cve, "publishedDate"))


### PR DESCRIPTION
This will get impact/severity from baseMetricV2 if baseMetricV3 does not exist.  Let's make sure this is what we want before merging this PR.

Also, this PR will conflict with PR #214.  PR #214 should be merged first, then I'll fix this one.