### PR TITLE
Add API to return last DB change

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -87,7 +87,7 @@ class DBChangeHandler(BaseHandler):
     """
     Class to return last-updated information from VMaaS DB
     """
-    def get(self):
+    def get(self): # pylint: disable=arguments-differ
         """
         ---
         description: Get last-updated-times for VMaaS DB

--- a/webapp/dbchange.py
+++ b/webapp/dbchange.py
@@ -2,10 +2,11 @@
 Module contains functions for returning last-modified data from the DB
 """
 
-from utils import format_datetime, parse_datetime
+from utils import format_datetime
 
 class DBChange(object):
     """ Main /dbchange API class. """
+    # pylint: disable=too-few-public-methods
     def __init__(self, database):
         self.cursor = database.dictcursor()
 

--- a/webapp/dbchange.py
+++ b/webapp/dbchange.py
@@ -1,0 +1,28 @@
+"""
+Module contains functions for returning last-modified data from the DB
+"""
+
+from utils import format_datetime, parse_datetime
+
+class DBChange(object):
+    """ Main /dbchange API class. """
+    def __init__(self, database):
+        self.cursor = database.dictcursor()
+
+    def process(self):
+        """
+        This method returns details of last-processed-time from the VMaaS DB
+
+        :returns: dictionary of errata_changes/cve_changes/repository_changes/last_change timestamps
+
+        """
+        query = 'SELECT * from dbchange'
+        self.cursor.execute(query)
+        updates = self.cursor.fetchall()
+
+        answer = {}
+        for row in updates:
+            for key, value in row.items():
+                answer[key] = format_datetime(value)
+
+        return answer


### PR DESCRIPTION
- Adds 'dbchange' table to schema to track errata/cve/repos/any most-recent-change
- Adds initial-insert to guarantee dbcnage starts out with 'time db was created'
- Adds functions to db to update the columns in dbchange
- Adds triggers to various tables to call the appropriate function, depending on
  which entity is changed
- adds webapp/dbchange.py to expose the API /api/v1/dbchange
- adds APISpec doc for same