### PR TITLE
rewrite /updates API to use cached data only

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -60,7 +60,7 @@ class BaseHandler(tornado.web.RequestHandler):
         if endpoint == '/cves':
             result = CveAPI(cursor).process_list(data)
         elif endpoint == '/updates':
-            result = UpdatesAPI(cursor, self.updatescache, self.repocache).process_list(data)
+            result = UpdatesAPI(self.updatescache, self.repocache).process_list(data)
         elif endpoint == '/repos':
             result = RepoAPI(cursor, self.repocache).process_list(data)
         elif endpoint == '/errata':
@@ -784,7 +784,7 @@ class Application(tornado.web.Application):
         setup_apispec(handlers)
         db_instance = Database()
         cursor = db_instance.cursor()
-        BaseHandler.updatescache = UpdatesCache(cursor)
+        BaseHandler.updatescache = UpdatesCache(db_instance)
         BaseHandler.repocache = RepoCache(cursor)
         self.reposcan_websocket_url = os.getenv("REPOSCAN_WEBSOCKET_URL", "ws://reposcan:8081/notifications")
         self.reposcan_websocket = None

--- a/webapp/database.py
+++ b/webapp/database.py
@@ -30,14 +30,27 @@ class Database(object):
                                            password=self.password,
                                            host=self.host,
                                            port=self.port)
-        self.connection.set_session(readonly=True, autocommit=True)
+        self.connection.set_session(readonly=True)
 
-    def cursor(self):
+    def cursor(self, name=None):
         """ Returns cursor object connected to the database."""
-        return self.connection.cursor()
+        return self.connection.cursor(name=name)
 
     def dictcursor(self):
         """
         Returns cursor object connected to the database that returns dictionary.
         """
         return self.connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+
+class NamedCursor(object):
+    """Wrapper class for named cursor."""
+    # pylint: disable=too-few-public-methods
+    def __init__(self, db_connection, name="default"):
+        self.cursor = db_connection.cursor(name=name)
+
+    def __enter__(self):
+        return self.cursor
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cursor.close()

--- a/webapp/utils.py
+++ b/webapp/utils.py
@@ -10,7 +10,7 @@ def join_packagename(name, epoch, version, release, arch):
     """
     Build a package name from the separate NEVRA parts
     """
-    epoch = str(epoch) + ':' if int(epoch) else ''
+    epoch = ("%s:" % epoch) if int(epoch) else ''
     return "%s-%s%s-%s.%s" % (name, epoch, version, release, arch)
 
 NEVRA_RE = re.compile(r'(.*)-(([0-9]+):)?([^-]+)-([^-]+)\.([a-z0-9_]+)')
@@ -31,7 +31,8 @@ def split_packagename(filename):
         return '', '', '', '', ''
 
     name, _, epoch, version, release, arch = match.groups()
-    epoch = int(epoch) if epoch is not None else 0
+    if epoch is None:
+        epoch = '0'
     return name, epoch, version, release, arch
 
 


### PR DESCRIPTION
Rewrite /updates API to not use database directly but to use precached data on webapp start. With 14000 repositories it takes 800 MB in memory. Using my sample request with 950 package NEVRAs it seems 25 times faster than before.

Note: In output JSON packages without security updates no longer have summary and description fields filled because such packages are not in cache.