### PR TITLE
Rewrite /updates to use disk dump instead of connect to database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - 8081:8081
     volumes:
       - vmaas-reposcan-tmp:/tmp
+      - vmaas-dump-data:/data:z
     depends_on:
       - database
 
@@ -42,6 +43,8 @@ services:
       - ./conf/webapp.env
     ports:
       - 8080:8080
+    volumes:
+      - vmaas-dump-data:/data:z
     depends_on:
       - database
       - reposcan
@@ -61,4 +64,5 @@ services:
 
 volumes:
   vmaas-db-data:
+  vmaas-dump-data:
   vmaas-reposcan-tmp:

--- a/reposcan/Dockerfile
+++ b/reposcan/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:27
+FROM fedora:28
 
 # defaults; will be overwritten by docker-compose.env
 ENV POSTGRESQL_HOST=database

--- a/reposcan/database/database_handler.py
+++ b/reposcan/database/database_handler.py
@@ -1,6 +1,7 @@
 """
 Module containing database handler class.
 """
+import os
 import psycopg2
 
 
@@ -33,3 +34,11 @@ class DatabaseHandler:
         """Rollback any pending transaction."""
         if cls.connection is not None:
             cls.connection.rollback()
+
+def init_db():
+    """Setup DB connection parameters"""
+    DatabaseHandler.db_name = os.getenv('POSTGRESQL_DATABASE', "vmaas")
+    DatabaseHandler.db_user = os.getenv('POSTGRESQL_USER', "vmaas_writer")
+    DatabaseHandler.db_pass = os.getenv('POSTGRESQL_PASSWORD', "vmaas_writer_passwd")
+    DatabaseHandler.db_host = os.getenv('POSTGRESQL_HOST', "database")
+    DatabaseHandler.db_port = os.getenv('POSTGRESQL_PORT', 5432)

--- a/reposcan/database/database_handler.py
+++ b/reposcan/database/database_handler.py
@@ -5,6 +5,18 @@ import os
 import psycopg2
 
 
+class NamedCursor:
+    """Wrapper class for named cursor."""
+    # pylint: disable=too-few-public-methods
+    def __init__(self, db_connection, name="default"):
+        self.cursor = db_connection.cursor(name=name)
+
+    def __enter__(self):
+        return self.cursor
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cursor.close()
+
 class DatabaseHandler:
     """Static class maintaining single PostgreSQL connection."""
     db_name = None

--- a/reposcan/exporter.py
+++ b/reposcan/exporter.py
@@ -1,0 +1,204 @@
+#!/usr/bin/python3
+"""
+Tool for exporting preprocessed data from database for webapp nodes.
+"""
+
+import shelve
+from common.logging import get_logger, init_logging
+from common.dateutil import format_datetime
+from database.database_handler import DatabaseHandler, NamedCursor, init_db
+
+DUMP = '/data/vmaas.dbm'
+LOGGER = get_logger(__name__)
+
+
+class DataDump:
+    """Class for creating disk dump from database."""
+    def __init__(self, db_instance, filename):
+        self.db_instance = db_instance
+        self.filename = filename
+        self.packagename_ids = []
+        self.package_ids = []
+        self.errata_ids = []
+
+    def _named_cursor(self):
+        return NamedCursor(self.db_instance)
+
+    def dump(self):
+        """Dump necessary data tu disk file"""
+        with shelve.open(self.filename, 'c') as dump:
+            self.dump_packagename(dump)
+            self.dump_updates(dump)
+            self.dump_evr(dump)
+            self.dump_arch(dump)
+            self.dump_arch_compat(dump)
+            self.dump_package_details(dump)
+            self.dump_repo(dump)
+            self.dump_errata(dump)
+
+    def dump_packagename(self, dump):
+        """Select all package names (only for package names with ever received sec. update)"""
+        with self._named_cursor() as cursor:
+            cursor.execute("""select distinct pn.id, pn.name
+                                from package_name pn inner join
+                                     package p on pn.id = p.name_id inner join
+                                     pkg_errata pe on p.id = pe.pkg_id inner join
+                                     errata e on pe.errata_id = e.id inner join
+                                     errata_type et on e.errata_type_id = et.id left join
+                                     errata_cve ec on e.id = ec.errata_id
+                               where et.name = 'security' or ec.cve_id is not null
+                            """)
+            for name_id, pkg_name in cursor:
+                dump["packagename2id:%s" % pkg_name] = name_id
+                dump["id2packagename:%s" % name_id] = pkg_name
+                self.packagename_ids.append(name_id)
+
+    def dump_updates(self, dump):
+        """Select ordered updates lists for previously selected package names"""
+        with self._named_cursor() as cursor:
+            cursor.execute("""select p.name_id, p.id, p.evr_id, p.arch_id
+                                from package p
+                          inner join evr on p.evr_id = evr.id
+                               where p.name_id in %s
+                               order by p.name_id, evr.evr
+                            """, [tuple(self.packagename_ids)])
+            index_cnt = {}
+            updates = {}
+            updates_index = {}
+            for name_id, pkg_id, evr_id, arch_id in cursor:
+                idx = index_cnt.get(name_id, 0)
+                updates.setdefault("updates:%s" % name_id, []).append(pkg_id)
+                updates_index.setdefault("updates_index:%s" % name_id,
+                                         {}).setdefault((evr_id, arch_id), []).append(idx)
+                idx += 1
+                index_cnt[name_id] = idx
+            dump.update(updates)
+            dump.update(updates_index)
+
+    def dump_evr(self, dump):
+        """Select all evrs and put them into dictionary"""
+        with self._named_cursor() as cursor:
+            cursor.execute("select id, epoch, version, release from evr")
+            for evr_id, epoch, ver, rel in cursor:
+                dump["evr2id:%s:%s:%s" % (epoch, ver, rel)] = evr_id
+                dump["id2evr:%s" % evr_id] = (epoch, ver, rel)
+
+    def dump_arch(self, dump):
+        """Select all archs and put them into dictionary"""
+        with self._named_cursor() as cursor:
+            cursor.execute("select id, name from arch")
+            for arch_id, name in cursor:
+                dump["arch2id:%s" % name] = arch_id
+                dump["id2arch:%s" % arch_id] = name
+
+    def dump_arch_compat(self, dump):
+        """Select information about archs compatibility"""
+        with self._named_cursor() as cursor:
+            cursor.execute("select from_arch_id, to_arch_id from arch_compatibility")
+            arch_compat = {}
+            for from_arch_id, to_arch_id in cursor:
+                arch_compat.setdefault("arch_compat:%s" % from_arch_id, set()).add(to_arch_id)
+            dump.update(arch_compat)
+
+    def dump_package_details(self, dump):
+        """Select details about packages (for previously selected package names)"""
+        with self._named_cursor() as cursor:
+            cursor.execute("""select id, name_id, evr_id, arch_id, summary, description
+                                from package
+                               where name_id in %s
+                           """, [tuple(self.packagename_ids)])
+            for pkg_id, name_id, evr_id, arch_id, summary, description in cursor:
+                dump["package_details:%s" % pkg_id] = (name_id, evr_id, arch_id, summary, description)
+                self.package_ids.append(pkg_id)
+
+    def dump_repo(self, dump):
+        """Select repo mappings"""
+        # pylint: disable=too-many-locals
+
+        # Select repo detail mapping
+        with self._named_cursor() as cursor:
+            cursor.execute("""select r.id,
+                                      cs.label,
+                                      cs.name as repo_name,
+                                      r.url,
+                                      a.name as basearch_name,
+                                      r.releasever,
+                                      p.name as product_name,
+                                      p.id as product_id,
+                                      r.revision
+                                 from repo r
+                                 join content_set cs on cs.id = r.content_set_id
+                                 join arch a on a.id = r.basearch_id
+                                 join product p on p.id = cs.product_id
+                                 """)
+            repolabel2ids = {}
+            productid2repoids = {}
+            for oid, label, name, url, basearch, releasever, product, product_id, revision in cursor:
+                dump["repo_detail:%s" % oid] = (label, name, url, basearch,
+                                                releasever, product, product_id,
+                                                format_datetime(revision))
+                repolabel2ids.setdefault("repolabel2ids:%s" % label, []).append(oid)
+                productid2repoids.setdefault("productid2repoids:%s" % product_id, []).append(oid)
+            dump.update(repolabel2ids)
+            dump.update(productid2repoids)
+
+        # Select package ID to repo IDs mapping
+        with self._named_cursor() as cursor:
+            cursor.execute("""select pkg_id, repo_id
+                                from pkg_repo
+                               where pkg_id in %s
+                           """, [tuple(self.package_ids)])
+            pkgid2repoids = {}
+            for pkg_id, repo_id in cursor:
+                pkgid2repoids.setdefault("pkgid2repoids:%s" % pkg_id, []).append(repo_id)
+            dump.update(pkgid2repoids)
+
+    def dump_errata(self, dump):
+        """Select errata mappings"""
+        # Select errata ID to name mapping
+        with self._named_cursor() as cursor:
+            cursor.execute("""select distinct e.id, e.name
+                                from errata e
+                          inner join errata_type et on e.errata_type_id = et.id
+                           left join errata_cve ec on e.id = ec.errata_id
+                               where et.name = 'security' or ec.cve_id is not null
+                           """)
+            for errata_id, errata_name in cursor:
+                dump["errataid2name:%s" % errata_id] = errata_name
+                self.errata_ids.append(errata_id)
+
+        # Select package ID to errata IDs mapping, only for relevant errata
+        with self._named_cursor() as cursor:
+            cursor.execute("""select pkg_id, errata_id
+                                from pkg_errata
+                               where errata_id in %s
+                            """, [tuple(self.errata_ids)])
+            pkgid2errataids = {}
+            for pkg_id, errata_id in cursor:
+                pkgid2errataids.setdefault("pkgid2errataids:%s" % pkg_id, set()).add(errata_id)
+            dump.update(pkgid2errataids)
+
+        # Select errata ID to repo IDs mapping, only for relevant errata
+        with self._named_cursor() as cursor:
+            cursor.execute("""select errata_id, repo_id
+                                from errata_repo
+                               where errata_id in %s
+                            """, [tuple(self.errata_ids)])
+            errataid2repoids = {}
+            for errata_id, repo_id in cursor:
+                errataid2repoids.setdefault("errataid2repoids:%s" % errata_id,
+                                            set()).add(repo_id)
+            dump.update(errataid2repoids)
+
+
+def main(filename):
+    """ Main loop."""
+    init_logging()
+    init_db()
+    db_instance = DatabaseHandler.get_connection()
+    #data = DataDump(db.cursor(), filename)
+    data = DataDump(db_instance, filename)
+    data.dump()
+
+if __name__ == '__main__':
+    main(DUMP)

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -15,7 +15,7 @@ from tornado.web import RequestHandler, Application
 from tornado.websocket import WebSocketHandler
 
 from common.logging import get_logger, init_logging
-from database.database_handler import DatabaseHandler
+from database.database_handler import DatabaseHandler, init_db
 from database.product_store import ProductStore
 from nistcve.cve_controller import CveRepoController
 from redhatcve.cvemap_controller import CvemapController
@@ -35,15 +35,6 @@ SPEC = APISpec(
 
 WEBSOCKET_PING_INTERVAL = 60
 WEBSOCKET_TIMEOUT = 300
-
-
-def init_db():
-    """Setup DB connection parameters"""
-    DatabaseHandler.db_name = os.getenv('POSTGRESQL_DATABASE', "vmaas")
-    DatabaseHandler.db_user = os.getenv('POSTGRESQL_USER', "vmaas_writer")
-    DatabaseHandler.db_pass = os.getenv('POSTGRESQL_PASSWORD', "vmaas_writer_passwd")
-    DatabaseHandler.db_host = os.getenv('POSTGRESQL_HOST', "database")
-    DatabaseHandler.db_port = os.getenv('POSTGRESQL_PORT', 5432)
 
 
 class NotificationHandler(WebSocketHandler):

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:27
+FROM fedora:28
 MAINTAINER Gennadii Altukhov <galt@redhat.com>
 
 # defaults; will be overwritten by docker-compose.env

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM fedora:27
 MAINTAINER Gennadii Altukhov <galt@redhat.com>
 
 # defaults; will be overwritten by docker-compose.env
@@ -10,12 +10,11 @@ ENV POSTGRESQL_DATABASE=vmaas
 
 ENV REPOSCAN_WEBSOCKET_URL=ws://reposcan:8081/notifications
 
-RUN curl -o /etc/yum.repos.d/group_vmaas-libs-epel-7.repo https://copr.fedorainfracloud.org/coprs/g/vmaas/libs/repo/epel-7/group_vmaas-libs-epel-7.repo
-
-RUN yum -y update \
-    && yum -y install epel-release \
-    && yum -y install python-tornado python-psycopg2 python2-apispec postgresql python-dateutil python2-futures python2-jsonschema \
-    && rm -rf /var/cache/yum/*
+RUN dnf -y update \
+    && dnf install -y dnf-plugins-core \
+    && dnf copr enable -y @vmaas/libs \
+    && dnf -y install python3-tornado python3-psycopg2 python3-apispec postgresql python3-dateutil python3-jsonschema \
+    && rm -rf /var/cache/dnf/*
 
 ADD ./wait-for-services.sh /app/wait-for-services.sh
 ADD ./entrypoint.sh /app/

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 """
 Main web API module
 """

--- a/webapp/cache.py
+++ b/webapp/cache.py
@@ -1,0 +1,94 @@
+"""
+Module to cache data from file dump.
+"""
+
+import dbm
+import shelve
+
+DUMP = '/data/vmaas.dbm'
+
+# repo_detail indexes
+REPO_LABEL = 0
+REPO_NAME = 1
+REPO_URL = 2
+REPO_BASEARCH = 3
+REPO_RELEASEVER = 4
+REPO_PRODUCT = 5
+REPO_PRODUCT_ID = 6
+REPO_REVISION = 7
+
+class Cache(object):
+    """ Cache class. """
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, filename=DUMP):
+        self.filename = filename
+        self.reload()
+
+    def reload(self):
+        """Clear dictionaries and load new data."""
+        self.packagename2id = {}
+        self.id2packagename = {}
+        self.updates = {}
+        self.updates_index = {}
+        self.evr2id = {}
+        self.id2evr = {}
+        self.arch2id = {}
+        self.id2arch = {}
+        self.arch_compat = {}
+        self.package_details = {}
+        self.repo_detail = {}
+        self.repolabel2ids = {}
+        self.productid2repoids = {}
+        self.pkgid2repoids = {}
+        self.errataid2name = {}
+        self.pkgid2errataids = {}
+        self.errataid2repoids = {}
+        self.load(self.filename)
+
+    def load(self, filename):
+        """Load data from shelve file into dictionaries."""
+        # pylint: disable=too-many-branches
+        try:
+            data = shelve.open(filename, 'r')
+        except dbm.error:
+            # file does not exist or has wrong type
+            return
+        for item in data:
+            relation, key = item.split(":", 1)
+            if relation == "packagename2id":
+                self.packagename2id[key] = data[item]
+            elif relation == "id2packagename":
+                self.id2packagename[int(key)] = data[item]
+            elif relation == "updates":
+                self.updates[int(key)] = data[item]
+            elif relation == "updates_index":
+                self.updates_index[int(key)] = data[item]
+            elif relation == "evr2id":
+                epoch, version, release = key.split(":", 2)
+                self.evr2id[(epoch, version, release)] = data[item]
+            elif relation == "id2evr":
+                self.id2evr[int(key)] = data[item]
+            elif relation == "arch2id":
+                self.arch2id[key] = data[item]
+            elif relation == "id2arch":
+                self.id2arch[int(key)] = data[item]
+            elif relation == "arch_compat":
+                self.arch_compat[int(key)] = data[item]
+            elif relation == "package_details":
+                self.package_details[int(key)] = data[item]
+            elif relation == "repo_detail":
+                self.repo_detail[int(key)] = data[item]
+            elif relation == "repolabel2ids":
+                self.repolabel2ids[key] = data[item]
+            elif relation == "productid2repoids":
+                self.productid2repoids[int(key)] = data[item]
+            elif relation == "pkgid2repoids":
+                self.pkgid2repoids[int(key)] = data[item]
+            elif relation == "errataid2name":
+                self.errataid2name[int(key)] = data[item]
+            elif relation == "pkgid2errataids":
+                self.pkgid2errataids[int(key)] = data[item]
+            elif relation == "errataid2repoids":
+                self.errataid2repoids[int(key)] = data[item]
+            else:
+                raise KeyError("Unknown relation in data: %s" % relation)

--- a/webapp/cve.py
+++ b/webapp/cve.py
@@ -56,7 +56,7 @@ class CveAPI(object):
         if not cves_to_process:
             return answer
 
-        cves_to_process = filter(None, cves_to_process)
+        cves_to_process = list(filter(None, cves_to_process))
         # Select all cves in request
         column_names = ["cve.id", "redhat_url", "secondary_url", "cve.name", "cvss3_score", "cve_impact.name",
                         "published_date", "modified_date", "iava", "description"]

--- a/webapp/errata.py
+++ b/webapp/errata.py
@@ -89,7 +89,7 @@ class ErrataAPI(object):
         if not errata_to_process:
             return response
 
-        errata_to_process = filter(None, errata_to_process)
+        errata_to_process = list(filter(None, errata_to_process))
         # Select all errata in request
         errata_query = """SELECT errata.id as oid,
                                  errata.name as name,

--- a/webapp/updates.py
+++ b/webapp/updates.py
@@ -4,7 +4,7 @@ Module to handle /updates API calls.
 
 from jsonschema import validate
 
-from database import NamedCursor
+from cache import REPO_LABEL, REPO_BASEARCH, REPO_RELEASEVER, REPO_PRODUCT_ID
 from utils import join_packagename, split_packagename
 
 
@@ -24,135 +24,11 @@ JSON_SCHEMA = {
 }
 
 
-class UpdatesCache(object):
-    """Cache which hold updates mappings."""
-    # pylint: disable=too-few-public-methods, too-many-instance-attributes, too-many-locals
-    def __init__(self, db_instance):
-        self.db_instance = db_instance
-        self.packagename2id = {}
-        self.id2packagename = {}
-        self.updates = {}
-        self.updates_index = {}
-        self.evr2id = {}
-        self.id2evr = {}
-        self.arch2id = {}
-        self.id2arch = {}
-        self.arch_compat = {}
-        self.package_details = {}
-        self.pkgid2repoids = {}
-        self.errataid2name = {}
-        self.pkgid2errataids = {}
-        self.errataid2repoids = {}
-        self.prepare()
-
-    def prepare(self):
-        """ Read ahead table of keys. """
-
-        # Select all package names (only for package names with ever received sec. update)
-        with NamedCursor(self.db_instance, name="updates-cache") as cursor:
-            cursor.execute("""select distinct pn.id, pn.name
-                              from package_name pn inner join
-                                   package p on pn.id = p.name_id inner join
-                                   pkg_errata pe on p.id = pe.pkg_id inner join
-                                   errata e on pe.errata_id = e.id inner join
-                                   errata_type et on e.errata_type_id = et.id left join
-                                   errata_cve ec on e.id = ec.errata_id
-                              where et.name = 'security' or ec.cve_id is not null
-                           """)
-            for name_id, pkg_name in cursor:
-                self.packagename2id[pkg_name] = name_id
-                self.id2packagename[name_id] = pkg_name
-
-        # Select ordered updates lists for previously selected package names
-        with NamedCursor(self.db_instance, name="updates-cache") as cursor:
-            cursor.execute("""select p.name_id, p.id, p.evr_id, p.arch_id
-                              from package p inner join 
-                                   evr on p.evr_id = evr.id
-                              where p.name_id in %s
-                              order by p.name_id, evr.evr
-                           """, [tuple(self.packagename2id.values())])
-            index_cnt = {}
-            for name_id, pkg_id, evr_id, arch_id in cursor:
-                idx = index_cnt.get(name_id, 0)
-                self.updates.setdefault(name_id, []).append(pkg_id)
-                self.updates_index.setdefault(name_id, {}).setdefault((evr_id, arch_id), []).append(idx)
-                idx += 1
-                index_cnt[name_id] = idx
-
-        # Select all evrs and put them into dictionary
-        with NamedCursor(self.db_instance, name="updates-cache") as cursor:
-            cursor.execute("select id, epoch, version, release from evr")
-            for evr_id, epoch, ver, rel in cursor:
-                self.evr2id[(epoch, ver, rel)] = evr_id
-                self.id2evr[evr_id] = (epoch, ver, rel)
-
-        # Select all archs and put them into dictionary
-        with NamedCursor(self.db_instance, name="updates-cache") as cursor:
-            cursor.execute("select id, name from arch")
-            for arch_id, name in cursor:
-                self.arch2id[name] = arch_id
-                self.id2arch[arch_id] = name
-
-        # Select information about archs compatibility
-        with NamedCursor(self.db_instance, name="updates-cache") as cursor:
-            cursor.execute("select from_arch_id, to_arch_id from arch_compatibility")
-            for from_arch_id, to_arch_id in cursor:
-                self.arch_compat.setdefault(from_arch_id, set()).add(to_arch_id)
-
-        # Select details about packages (for previously selected package names)
-        with NamedCursor(self.db_instance, name="updates-cache") as cursor:
-            cursor.execute("""select id, name_id, evr_id, arch_id, summary, description
-                              from package
-                              where name_id in %s
-                           """, [tuple(self.packagename2id.values())])
-            for pkg_id, name_id, evr_id, arch_id, summary, description in cursor:
-                self.package_details[pkg_id] = (name_id, evr_id, arch_id, summary, description)
-
-        # Select package ID to repo IDs mapping
-        with NamedCursor(self.db_instance, name="updates-cache") as cursor:
-            cursor.execute("""select pkg_id, repo_id
-                              from pkg_repo
-                              where pkg_id in %s
-                           """, [tuple(self.package_details.keys())])
-            for pkg_id, repo_id in cursor:
-                self.pkgid2repoids.setdefault(pkg_id, []).append(repo_id)
-
-        # Select errata ID to name mapping
-        with NamedCursor(self.db_instance, name="updates-cache") as cursor:
-            cursor.execute("""select distinct e.id, e.name
-                              from errata e inner join
-                                   errata_type et on e.errata_type_id = et.id left join
-                                   errata_cve ec on e.id = ec.errata_id
-                              where et.name = 'security' or ec.cve_id is not null
-                           """)
-            for errata_id, errata_name in cursor:
-                self.errataid2name[errata_id] = errata_name
-
-        # Select package ID to errata IDs mapping, only for relevant errata
-        with NamedCursor(self.db_instance, name="updates-cache") as cursor:
-            cursor.execute("""select pkg_id, errata_id
-                              from pkg_errata
-                              where errata_id in %s
-                           """, [tuple(self.errataid2name.keys())])
-            for pkg_id, errata_id in cursor:
-                self.pkgid2errataids.setdefault(pkg_id, set()).add(errata_id)
-
-        # Select errata ID to repo IDs mapping, only for relevant errata
-        with NamedCursor(self.db_instance, name="updates-cache") as cursor:
-            cursor.execute("""select errata_id, repo_id
-                              from errata_repo
-                              where errata_id in %s
-                           """, [tuple(self.errataid2name.keys())])
-            for errata_id, repo_id in cursor:
-                self.errataid2repoids.setdefault(errata_id, set()).add(repo_id)
-
-
 class UpdatesAPI(object):
     """ Main /updates API class."""
     # pylint: disable=too-few-public-methods
-    def __init__(self, updatescache, repocache):
-        self.updatescache = updatescache
-        self.repocache = repocache
+    def __init__(self, cache):
+        self.cache = cache
 
     def _process_repositories(self, data, response):
         # Read list of repositories
@@ -160,23 +36,23 @@ class UpdatesAPI(object):
         if repo_list is not None:
             repo_ids = []
             for label in repo_list:
-                repo_ids.extend(self.repocache.label2ids(label))
+                repo_ids.extend(self.cache.repolabel2ids[label])
             response['repository_list'] = repo_list
         else:
-            repo_ids = self.repocache.all_ids()
+            repo_ids = self.cache.repo_detail.keys()
 
         # Filter out repositories of different releasever
         releasever = data.get('releasever', None)
         if releasever is not None:
             repo_ids = [oid for oid in repo_ids
-                        if self.repocache.get_by_id(oid)['releasever'] == releasever]
+                        if self.cache.repo_detail[oid][REPO_RELEASEVER] == releasever]
             response['releasever'] = releasever
 
         # Filter out repositories of different basearch
         basearch = data.get('basearch', None)
         if basearch is not None:
             repo_ids = [oid for oid in repo_ids
-                        if self.repocache.get_by_id(oid)['basearch'] == basearch]
+                        if self.cache.repo_detail[oid][REPO_BASEARCH] == basearch]
             response['basearch'] = basearch
 
         return set(repo_ids)
@@ -189,21 +65,21 @@ class UpdatesAPI(object):
             for pkg in packages_to_process:
                 response['update_list'][pkg] = {}
                 name, epoch, ver, rel, arch = split_packagename(pkg)
-                if name in self.updatescache.packagename2id:
-                    if self.updatescache.packagename2id[name] in self.updatescache.updates_index:
+                if name in self.cache.packagename2id:
+                    if self.cache.packagename2id[name] in self.cache.updates_index:
                         filtered_packages_to_process[pkg] = {'parsed_nevra': (name, epoch, ver, rel, arch)}
         return filtered_packages_to_process
 
     def _get_related_products(self, original_package_repo_ids):
         product_ids = set()
         for original_package_repo_id in original_package_repo_ids:
-            product_ids.add(self.repocache.id2productid(original_package_repo_id))
+            product_ids.add(self.cache.repo_detail[original_package_repo_id][REPO_PRODUCT_ID])
         return product_ids
 
     def _get_valid_releasevers(self, original_package_repo_ids):
         valid_releasevers = set()
         for original_package_repo_id in original_package_repo_ids:
-            valid_releasevers.add(self.repocache.get_by_id(original_package_repo_id)['releasever'])
+            valid_releasevers.add(self.cache.repo_detail[original_package_repo_id][REPO_RELEASEVER])
         return valid_releasevers
 
     # pylint: disable=too-many-arguments
@@ -211,33 +87,33 @@ class UpdatesAPI(object):
         repo_ids = []
         errata_repo_ids = set()
         for errata_id in errata_ids:
-            for repo_id in self.updatescache.errataid2repoids[errata_id]:
+            for repo_id in self.cache.errataid2repoids.get(errata_id, []):
                 errata_repo_ids.add(repo_id)
 
-        for repo_id in self.updatescache.pkgid2repoids[update_pkg_id]:
+        for repo_id in self.cache.pkgid2repoids.get(update_pkg_id, []):
             if repo_id in available_repo_ids \
-                    and self.repocache.id2productid(repo_id) in product_ids \
+                    and self.cache.repo_detail[repo_id][REPO_PRODUCT_ID] in product_ids \
                     and repo_id in errata_repo_ids \
-                    and self.repocache.get_by_id(repo_id)['releasever'] in valid_releasevers:
+                    and self.cache.repo_detail[repo_id][REPO_RELEASEVER] in valid_releasevers:
                 repo_ids.append(repo_id)
 
         return repo_ids
 
     def _build_nevra(self, update_pkg_id):
-        name_id, evr_id, arch_id, _, _ = self.updatescache.package_details[update_pkg_id]
-        name = self.updatescache.id2packagename[name_id]
-        epoch, ver, rel = self.updatescache.id2evr[evr_id]
-        arch = self.updatescache.id2arch[arch_id]
+        name_id, evr_id, arch_id, _, _ = self.cache.package_details[update_pkg_id]
+        name = self.cache.id2packagename[name_id]
+        epoch, ver, rel = self.cache.id2evr[evr_id]
+        arch = self.cache.id2arch[arch_id]
         return join_packagename(name, epoch, ver, rel, arch)
 
     def _process_updates(self, packages_to_process, available_repo_ids, response):
         # pylint: disable=too-many-locals
         for pkg, pkg_dict in packages_to_process.items():
             name, epoch, ver, rel, arch = pkg_dict['parsed_nevra']
-            name_id = self.updatescache.packagename2id[name]
-            evr_id = self.updatescache.evr2id.get((epoch, ver, rel), None)
-            arch_id = self.updatescache.arch2id.get(arch, None)
-            current_version_indexes = self.updatescache.updates_index[name_id].get((evr_id, arch_id), [])
+            name_id = self.cache.packagename2id[name]
+            evr_id = self.cache.evr2id.get((epoch, ver, rel), None)
+            arch_id = self.cache.arch2id.get(arch, None)
+            current_version_indexes = self.cache.updates_index[name_id].get((evr_id, arch_id), [])
 
             # Package with given NEVRA not found in cache/DB
             if not current_version_indexes:
@@ -246,54 +122,54 @@ class UpdatesAPI(object):
             current_version_pkg_ids = set()
             pkg_id = None
             for current_version_index in current_version_indexes:
-                pkg_id = self.updatescache.updates[name_id][current_version_index]
+                pkg_id = self.cache.updates[name_id][current_version_index]
                 current_version_pkg_ids.add(pkg_id)
 
             _, _, current_version_arch_id, summary, description = \
-                self.updatescache.package_details[pkg_id]
+                self.cache.package_details[pkg_id]
             response['update_list'][pkg]['summary'] = summary
             response['update_list'][pkg]['description'] = description
             response['update_list'][pkg]['available_updates'] = []
 
             # No updates found for given NEVRA
-            last_version_pkg_id = self.updatescache.updates[name_id][-1]
+            last_version_pkg_id = self.cache.updates[name_id][-1]
             if last_version_pkg_id in current_version_pkg_ids:
                 continue
 
             # Get associated product IDs
             original_package_repo_ids = set()
             for current_version_pkg_id in current_version_pkg_ids:
-                original_package_repo_ids.update(self.updatescache.pkgid2repoids[current_version_pkg_id])
+                original_package_repo_ids.update(self.cache.pkgid2repoids.get(current_version_pkg_id, []))
             product_ids = self._get_related_products(original_package_repo_ids)
             valid_releasevers = self._get_valid_releasevers(original_package_repo_ids)
 
             # Get candidate package IDs
-            update_pkg_ids = self.updatescache.updates[name_id][current_version_indexes[-1] + 1:]
+            update_pkg_ids = self.cache.updates[name_id][current_version_indexes[-1] + 1:]
 
             for update_pkg_id in update_pkg_ids:
                 # Filter out packages without errata
-                if update_pkg_id not in self.updatescache.pkgid2errataids:
+                if update_pkg_id not in self.cache.pkgid2errataids:
                     continue
 
                 # Filter arch compatibility
-                _, _, updated_version_arch_id, _, _ = self.updatescache.package_details[update_pkg_id]
+                _, _, updated_version_arch_id, _, _ = self.cache.package_details[update_pkg_id]
                 if (updated_version_arch_id != current_version_arch_id
-                        and updated_version_arch_id not in self.updatescache.arch_compat[current_version_arch_id]):
+                        and updated_version_arch_id not in self.cache.arch_compat[current_version_arch_id]):
                     continue
 
-                errata_ids = self.updatescache.pkgid2errataids.get(update_pkg_id, set())
+                errata_ids = self.cache.pkgid2errataids.get(update_pkg_id, set())
                 repo_ids = self._get_repositories(product_ids, update_pkg_id, errata_ids, available_repo_ids,
                                                   valid_releasevers)
                 nevra = self._build_nevra(update_pkg_id)
                 for repo_id in repo_ids:
-                    repo_details = self.repocache.get_by_id(repo_id)
+                    repo_details = self.cache.repo_detail[repo_id]
                     for errata_id in errata_ids:
                         response['update_list'][pkg]['available_updates'].append({
                             'package': nevra,
-                            'erratum': self.updatescache.errataid2name[errata_id],
-                            'repository': repo_details['label'],
-                            'basearch': repo_details['basearch'],
-                            'releasever': repo_details['releasever']
+                            'erratum': self.cache.errataid2name[errata_id],
+                            'repository': repo_details[REPO_LABEL],
+                            'basearch': repo_details[REPO_BASEARCH],
+                            'releasever': repo_details[REPO_RELEASEVER]
                         })
 
     def process_list(self, data):


### PR DESCRIPTION
Disk dump of data allows us to separate master database from webapps and possibly add  on-premise/disconnected features.