### PR TITLE
Make errata api use Phase II design

### DIFF
--- a/reposcan/exporter.py
+++ b/reposcan/exporter.py
@@ -195,6 +195,50 @@ class DataDump:
                                                 set()).add(repo_id)
                 dump.update(errataid2repoids)
 
+        # Select errata detail for errata API
+        errataid2cves = {}
+        with self._named_cursor() as cursor:
+            cursor.execute("""SELECT errata_cve.errata_id, cve.name
+                                FROM cve
+                                JOIN errata_cve ON cve_id = cve.id
+                           """)
+            for errata_id, cve_name in cursor:
+                errataid2cves.setdefault(errata_id, []).append(cve_name)
+        errataid2pkgid = {}
+        with self._named_cursor() as cursor:
+            cursor.execute("""SELECT errata_id, pkg_id FROM pkg_errata""")
+            for errata_id, pkg_id in cursor:
+                errataid2pkgid.setdefault(errata_id, []).append(pkg_id)
+        errataid2bzs = {}
+        errataid2refs = {}
+        with self._named_cursor() as cursor:
+            cursor.execute("SELECT errata_id, type, name FROM errata_refs")
+            for errata_id, ref_type, ref_name in cursor:
+                if ref_type == 'bugzilla':
+                    errataid2bzs.setdefault(errata_id, []).append(ref_name)
+                else:
+                    errataid2refs.setdefault(errata_id, []).append(ref_name)
+        # Now pull all the data together for the dump
+        with self._named_cursor() as cursor:
+            cursor.execute("""SELECT errata.id, errata.name, synopsis, summary,
+                                     errata_type.name, errata_severity.name,
+                                     description, solution, issued, updated
+                                FROM errata
+                                JOIN errata_type ON errata_type_id = errata_type.id
+                                JOIN errata_severity ON severity_id = errata_severity.id
+                           """)
+            for errata_id, e_name, synopsis, summary, e_type, e_severity, \
+                description, solution, issued, updated in cursor:
+                url = "https://access.redhat.com/errata/%s" % e_name
+                dump["errata_detail:%s" % e_name] = (synopsis, summary, e_type,
+                                                     e_severity, description,
+                                                     solution, issued, updated,
+                                                     errataid2cves.get(errata_id, []),
+                                                     errataid2pkgid.get(errata_id, []),
+                                                     errataid2bzs.get(errata_id, []),
+                                                     errataid2refs.get(errata_id, []),
+                                                     url)
+
     def dump_cves(self, dump):
         """Select cve details"""
         # Select CWE to CVE mapping

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -57,7 +57,7 @@ class BaseHandler(tornado.web.RequestHandler):
         elif endpoint == '/repos':
             result = self.repo_api.process_list(data)
         elif endpoint == '/errata':
-            result = ErrataAPI(db_instance).process_list(data)
+            result = ErrataAPI(self.db_cache).process_list(data)
         elif endpoint == '/dbchange':
             result = DBChange(self.db_cache).process()
         elif endpoint == '/apispec':

--- a/webapp/cache.py
+++ b/webapp/cache.py
@@ -30,6 +30,21 @@ CVE_IAVA = 6
 CVE_DESCRIPTION = 7
 CVE_CWE = 8
 
+# errata detail indexes
+ERRATA_SYNOPSIS = 0
+ERRATA_SUMMARY = 1
+ERRATA_TYPE = 2
+ERRATA_SEVERITY = 3
+ERRATA_DESCRIPTION = 4
+ERRATA_SOLUTION = 5
+ERRATA_ISSUED = 6
+ERRATA_UPDATED = 7
+ERRATA_CVE = 8
+ERRATA_PKGIDS = 9
+ERRATA_BUGZILLA = 10
+ERRATA_REFERENCE = 11
+ERRATA_URL = 12
+
 class Cache(object):
     """ Cache class. """
     # pylint: disable=too-many-instance-attributes
@@ -54,6 +69,7 @@ class Cache(object):
         self.errataid2repoids = {}
         self.cve_detail = {}
         self.dbchange = {}
+        self.errata_detail = {}
         self.reload()
 
     def clear(self):
@@ -77,6 +93,7 @@ class Cache(object):
         self.errataid2repoids = {}
         self.cve_detail = {}
         self.dbchange = {}
+        self.errata_detail = {}
 
     def reload(self):
         """Update data and reload dictionaries."""
@@ -138,5 +155,7 @@ class Cache(object):
                 self.cve_detail[key] = data[item]
             elif relation == "dbchange":
                 self.dbchange[key] = data[item]
+            elif relation == "errata_detail":
+                self.errata_detail[key] = data[item]
             else:
                 raise KeyError("Unknown relation in data: %s" % relation)

--- a/webapp/errata.py
+++ b/webapp/errata.py
@@ -2,73 +2,36 @@
 Module contains classes for returning errata data from DB
 """
 
-from utils import format_datetime, parse_datetime, join_packagename
+import re
 
+from utils import format_datetime, parse_datetime, none2empty, join_packagename
+from cache import ERRATA_SYNOPSIS, ERRATA_SUMMARY, ERRATA_TYPE, \
+                  ERRATA_SEVERITY, ERRATA_DESCRIPTION, ERRATA_SOLUTION, \
+                  ERRATA_ISSUED, ERRATA_UPDATED, ERRATA_CVE, ERRATA_PKGIDS, \
+                  ERRATA_BUGZILLA, ERRATA_REFERENCE, ERRATA_URL
 
 class ErrataAPI(object):
     """ Main /errata API class. """
-    def __init__(self, database):
-        self.cursor = database.dictcursor()
+    def __init__(self, cache):
+        self.cache = cache
 
-    def set_cves_for_errata(self, errata_map):
-        """
-        Populate the errata in the given errata_map with each erratum's
-        list of cves.
-        """
-        cve_query = """SELECT errata_cve.errata_id as erratum_id,
-                              cve.name as cve_name
-                         FROM cve
-                         JOIN errata_cve ON cve_id = cve.id
-                        WHERE errata_cve.errata_id IN %s"""
-        self.cursor.execute(cve_query, [tuple(errata_map.keys())])
-        results = self.cursor.fetchall()
-        for result in results:
-            errata_map[result['erratum_id']]['cve_list'].append(result['cve_name'])
+    def find_errata_by_regex(self, regex):
+        """Returns list of errata matching a provided regex."""
+        return [label for label in self.cache.errata_detail
+                if re.match(regex, label)]
 
-    def set_packages_for_errata(self, errata_map):
+    def pkgidlist2packages(self, pkgid_list):
         """
-        Populate the errata in the given errata_map with each erratum's
-        list of packages.
+        This method returns a list of packages for the given list of package ids.
         """
-        pkg_query = """SELECT pkg_errata.errata_id as erratum_id,
-                              package_name.name as name,
-                              evr.epoch as epoch,
-                              evr.version as version,
-                              evr.release as release,
-                              arch.name as arch
-                         FROM pkg_errata
-                         JOIN package ON package.id = pkg_errata.pkg_id
-                         JOIN package_name ON package_name.id = package.name_id
-                         JOIN evr ON evr.id = package.evr_id
-                         JOIN arch ON arch.id = package.arch_id
-                        WHERE pkg_errata.errata_id IN %s"""
-        self.cursor.execute(pkg_query, [tuple(errata_map.keys())])
-        results = self.cursor.fetchall()
-        for result in results:
-            packagename = join_packagename(result['name'],
-                                           result['epoch'],
-                                           result['version'],
-                                           result['release'],
-                                           result['arch'])
-            errata_map[result['erratum_id']]['package_list'].append(packagename)
-
-    def set_references_for_errata(self, errata_map):
-        """
-        Populate the errata in the given errata_map with each erratum's
-        list of references (bugzilla and other).
-        """
-        refs_query = """SELECT errata_id as erratum_id,
-                               type as ref_type,
-                               name
-                          FROM errata_refs
-                         WHERE errata_id IN %s"""
-        self.cursor.execute(refs_query, [tuple(errata_map.keys())])
-        results = self.cursor.fetchall()
-        for result in results:
-            if result['ref_type'] == 'bugzilla':
-                errata_map[result['erratum_id']]['bugzilla_list'].append(result['name'])
-            else:
-                errata_map[result['erratum_id']]['reference_list'].append(result['name'])
+        pkg_list = []
+        cch = self.cache
+        for pkg_id in pkgid_list:
+            name = cch.id2packagename[cch.package_details[pkg_id][0]]
+            epoch, ver, rel = cch.id2evr[cch.package_details[pkg_id][1]]
+            arch = cch.id2arch[cch.package_details[pkg_id][2]]
+            pkg_list.append(join_packagename(name, epoch, ver, rel, arch))
+        return pkg_list
 
     def process_list(self, data):
         """
@@ -81,7 +44,9 @@ class ErrataAPI(object):
         """
 
         modified_since = data.get("modified_since", None)
+        modified_since_dt = parse_datetime(modified_since)
         errata_to_process = data.get("errata_list", None)
+
         response = {"errata_list": {}}
         if modified_since:
             response["modified_since"] = modified_since
@@ -89,54 +54,34 @@ class ErrataAPI(object):
         if not errata_to_process:
             return response
 
-        errata_to_process = list(filter(None, errata_to_process))
-        # Select all errata in request
-        errata_query = """SELECT errata.id as oid,
-                                 errata.name as name,
-                                 synopsis,
-                                 summary,
-                                 errata_type.name as type,
-                                 errata_severity.name as severity,
-                                 description,
-                                 solution,
-                                 issued,
-                                 updated
-                            FROM errata
-                            JOIN errata_type ON errata_type_id = errata_type.id
-                            JOIN errata_severity ON severity_id = errata_severity.id
-                           WHERE"""
-
         if len(errata_to_process) == 1:
-            errata_query += " errata.name ~ %s"
-            errata_query_params = errata_to_process
-        else:
-            errata_query += " errata.name IN %s"
-            errata_query_params = [tuple(errata_to_process)]
-        if modified_since:
-            errata_query += " and errata.updated >= %s"
-            errata_query_params.append(parse_datetime(modified_since))
-        self.cursor.execute(errata_query, errata_query_params)
-        errata_results = self.cursor.fetchall()
+            # treat single-label like a regex, get all matching names
+            errata_to_process = self.find_errata_by_regex(errata_to_process[0])
 
-        errata_map = {} # map keyed on oid for populating lists in errata
-        response_dict = {} # map keyed on erratum name to return to caller
-        for erratum in errata_results:
-            oid = erratum.pop('oid')
-            erratum_name = erratum.pop('name')
-            erratum['updated'] = format_datetime(erratum['updated'])
-            erratum['issued'] = format_datetime(erratum['issued'])
-            erratum['bugzilla_list'] = []
-            erratum['package_list'] = []
-            erratum['reference_list'] = []
-            erratum['cve_list'] = []
-            erratum['url'] = "https://access.redhat.com/errata/%s" % erratum_name
-            errata_map[oid] = erratum
-            response_dict[erratum_name] = erratum
+        errata_list = {}
+        for errata in errata_to_process:
+            errata_detail = self.cache.errata_detail.get(errata, None)
+            if not errata_detail:
+                continue
 
-        if errata_map:
-            self.set_cves_for_errata(errata_map)
-            self.set_packages_for_errata(errata_map)
-            self.set_references_for_errata(errata_map)
+            if modified_since and (errata_detail[ERRATA_UPDATED] < modified_since_dt
+                                   and errata_detail[ERRATA_ISSUED] < modified_since_dt):
+                continue
 
-        response["errata_list"] = response_dict
+            errata_list[errata] = {
+                "synopsis": none2empty(errata_detail[ERRATA_SYNOPSIS]),
+                "summary": none2empty(errata_detail[ERRATA_SUMMARY]),
+                "type": none2empty(errata_detail[ERRATA_TYPE]),
+                "severity": none2empty(errata_detail[ERRATA_SEVERITY]),
+                "description": none2empty(errata_detail[ERRATA_DESCRIPTION]),
+                "solution": none2empty(errata_detail[ERRATA_SOLUTION]),
+                "issued": none2empty(format_datetime(errata_detail[ERRATA_ISSUED])),
+                "updated": none2empty(format_datetime(errata_detail[ERRATA_UPDATED])),
+                "cve_list": errata_detail[ERRATA_CVE],
+                "package_list": self.pkgidlist2packages(errata_detail[ERRATA_PKGIDS]),
+                "bugzilla_list": errata_detail[ERRATA_BUGZILLA],
+                "reference_list": errata_detail[ERRATA_REFERENCE],
+                "url": none2empty(errata_detail[ERRATA_URL])
+                }
+        response["errata_list"] = errata_list
         return response


### PR DESCRIPTION
I have cut-n-pasted the join_packagename() method from webapp/utils.py to reposcan/common/package_utils.py.  I'll open an issue that this should possibly be move to a utils or lib that gets used by both webapp and reposcan.