### PR TITLE
#301 api: updates: if all packages are in the hot cache already, we need to fill a response with the input repo information anyway.

### DIFF
--- a/webapp/updates.py
+++ b/webapp/updates.py
@@ -254,7 +254,6 @@ class UpdatesAPI(object):
 
     def _process_updates(self, packages_to_process, available_repo_ids, response):
         for pkg, pkg_dict in packages_to_process.items():
-            self.hot_cache.insert(pkg, {})
 
             name, epoch, ver, rel, arch = pkg_dict['parsed_nevra']
             name_id = self.cache.packagename2id[name]
@@ -366,11 +365,11 @@ class UpdatesAPI(object):
         # Return empty update list in case of empty input package list
         packages_to_process = self._process_input_packages(data, response)
 
-        if not packages_to_process:
-            return response
-
         # Get list of valid repository IDs based on input paramaters
         available_repo_ids = self._process_repositories(data, response)
+
+        if not packages_to_process:
+            return response
 
         # Process updated packages, errata and fill the response
         self._process_updates(packages_to_process, available_repo_ids, response)


### PR DESCRIPTION
INPUT:
```javascript
{
    "repository_list": [
        "rhel-7-server-rpms"
    ],
    "releasever": "7Server",
    "basearch": "x86_64",
    "package_list": [
        "dconf-0.26.0-2.el7.x86_64"
    ]
}
```


OUTPUT:

```javascript
{
    "update_list": {
        "dconf-0.26.0-2.el7.x86_64": {
            "summary": "A configuration system",
            "description": "dconf is a low-level configuration system. Its main purpose is to provide a\nbackend to the GSettings API in GLib.",
            "available_updates": [

            ]
        }
    },
    "repository_list": [
        "rhel-7-server-rpms"
    ],
    "releasever": "7Server",
    "basearch": "x86_64"
}
```