### PR TITLE
copy the data behind the symlink not link itself

### DIFF
--- a/webapp/cache.py
+++ b/webapp/cache.py
@@ -104,7 +104,7 @@ class Cache(object):
     @staticmethod
     def download():
         """Download new version of data."""
-        return not os.system("rsync -a --quiet %s %s" % (REMOTE_DUMP, DUMP))
+        return not os.system("rsync -a --copy-links --quiet %s %s" % (REMOTE_DUMP, DUMP))
 
     def load(self, filename):
         """Load data from shelve file into dictionaries."""


### PR DESCRIPTION
Fixes an issue on webapp
vmaas-webapp | rsync: symlink "/data/vmaas.dbm" -> "/data/vmaas.dbm-2018-06-18T08:31:32.670869+00:00" failed: File exists (17)
vmaas-webapp | rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1659) [generator=3.1.3]