### PR TITLE
fix #320 - don't convert None into string, just return None

### DIFF
--- a/webapp/utils.py
+++ b/webapp/utils.py
@@ -41,7 +41,7 @@ def format_datetime(datetime_obj):
     """Try to format object to ISO 8601 if object is datetime."""
     if isinstance(datetime_obj, datetime):
         return datetime_obj.isoformat()
-    return str(datetime_obj)
+    return None if datetime_obj is None else str(datetime_obj)
 
 def parse_datetime(date):
     """Parse date from string in ISO format."""


### PR DESCRIPTION
when format_datetime received None it converted into string "None"
which was confusing for subsequent calls with returned value
which were doing tests for None as "None" is None == False