### PR TITLE
Reposcan refactoring

### DIFF
--- a/database/vmaas_db_postgresql.sql
+++ b/database/vmaas_db_postgresql.sql
@@ -481,7 +481,7 @@ CREATE TABLE IF NOT EXISTS repo (
   basearch_id INT NOT NULL,
   releasever TEXT NOT NULL, CHECK (NOT empty(releasever)),
   eol BOOLEAN NOT NULL,
-  revision TIMESTAMP WITH TIME ZONE NOT NULL,
+  revision TIMESTAMP WITH TIME ZONE NULL,
   certificate_id INT NULL,
   PRIMARY KEY (id),
   UNIQUE (content_set_id, basearch_id, releasever),

--- a/database/vmaas_db_postgresql.sql
+++ b/database/vmaas_db_postgresql.sql
@@ -478,13 +478,12 @@ CREATE TABLE IF NOT EXISTS repo (
   id SERIAL,
   url TEXT NOT NULL, CHECK (NOT empty(url)),
   content_set_id INT NOT NULL,
-  basearch_id INT NOT NULL,
-  releasever TEXT NOT NULL, CHECK (NOT empty(releasever)),
+  basearch_id INT NULL,
+  releasever TEXT NULL, CHECK (NOT empty(releasever)),
   eol BOOLEAN NOT NULL,
   revision TIMESTAMP WITH TIME ZONE NULL,
   certificate_id INT NULL,
   PRIMARY KEY (id),
-  UNIQUE (content_set_id, basearch_id, releasever),
   CONSTRAINT content_set_id
     FOREIGN KEY (content_set_id)
     REFERENCES content_set (id),
@@ -495,6 +494,10 @@ CREATE TABLE IF NOT EXISTS repo (
     FOREIGN KEY (certificate_id)
     REFERENCES certificate (id)
 )TABLESPACE pg_default;
+CREATE UNIQUE INDEX repo_content_set_id_key ON repo (content_set_id) WHERE basearch_id IS NULL AND releasever IS NULL;
+CREATE UNIQUE INDEX repo_content_set_id_basearch_id_key ON repo (content_set_id, basearch_id) WHERE basearch_id IS NOT NULL AND releasever IS NULL;
+CREATE UNIQUE INDEX repo_content_set_id_releasever_key ON repo (content_set_id, releasever) WHERE basearch_id IS NULL AND releasever IS NOT NULL;
+CREATE UNIQUE INDEX repo_content_set_id_basearch_id_releasever_key ON repo (content_set_id, basearch_id, releasever) WHERE basearch_id IS NOT NULL AND releasever IS NOT NULL;
 CREATE TRIGGER repo_changed AFTER INSERT OR UPDATE OR DELETE ON repo
   FOR EACH STATEMENT
   EXECUTE PROCEDURE repos_changed();

--- a/reposcan/common/batch_list.py
+++ b/reposcan/common/batch_list.py
@@ -3,16 +3,13 @@ Module containing class for list of batches.
 """
 import os
 
-DEFAULT_BATCH_SIZE = 100
+DEFAULT_BATCH_SIZE = "100"
 
 class BatchList:
     """List of lists with defined maximum size of inner lists."""
 
-    def __init__(self, max_batch_size=-1):
-        # If batch-size not specified, use setting from env or default if unset
-        if max_batch_size == -1:
-            max_batch_size = os.getenv('BATCH_SIZE', DEFAULT_BATCH_SIZE)
-        self.max_batch_size = int(max_batch_size)
+    def __init__(self):
+        self.max_batch_size = int(os.getenv('BATCH_SIZE', DEFAULT_BATCH_SIZE))
         self.batches = []
 
     def __iter__(self):

--- a/reposcan/database/database_handler.py
+++ b/reposcan/database/database_handler.py
@@ -52,4 +52,4 @@ def init_db():
     DatabaseHandler.db_user = os.getenv('POSTGRESQL_USER', "vmaas_writer")
     DatabaseHandler.db_pass = os.getenv('POSTGRESQL_PASSWORD', "vmaas_writer_passwd")
     DatabaseHandler.db_host = os.getenv('POSTGRESQL_HOST', "database")
-    DatabaseHandler.db_port = os.getenv('POSTGRESQL_PORT', 5432)
+    DatabaseHandler.db_port = int(os.getenv('POSTGRESQL_PORT', "5432"))

--- a/reposcan/database/product_store.py
+++ b/reposcan/database/product_store.py
@@ -14,8 +14,6 @@ class ProductStore:
     def __init__(self):
         self.logger = get_logger(__name__)
         self.conn = DatabaseHandler.get_connection()
-        # Access this dictionary from repository_store to reference content set table.
-        self.cs_to_dbid = {}
 
     def _import_products(self, products):
         product_to_dbid = {}
@@ -45,24 +43,25 @@ class ProductStore:
         product_to_dbid = self._import_products(products)
         all_content_set_labels = [cs for product in products.values() for cs in product["content_sets"]]
         self.logger.debug("Syncing %d content sets.", len(all_content_set_labels))
+        cs_to_dbid = {}
         cur = self.conn.cursor()
         cur.execute("select id, label from content_set where label in %s", (tuple(all_content_set_labels),))
         for row in cur.fetchall():
-            self.cs_to_dbid[row[1]] = row[0]
+            cs_to_dbid[row[1]] = row[0]
         missing_content_sets = []
         for product in products:
             for content_set in products[product]["content_sets"]:
-                if content_set not in self.cs_to_dbid:
+                if content_set not in cs_to_dbid:
                     # label, name, product_id
                     missing_content_sets.append((content_set, products[product]["content_sets"][content_set],
                                                  product_to_dbid[product]))
-        self.logger.debug("Content sets already in DB: %d", len(self.cs_to_dbid))
+        self.logger.debug("Content sets already in DB: %d", len(cs_to_dbid))
         self.logger.debug("Content sets to import: %d", len(missing_content_sets))
         if missing_content_sets:
             execute_values(cur, """insert into content_set (label, name, product_id) values %s
                                    returning id, label""", missing_content_sets, page_size=len(missing_content_sets))
             for row in cur.fetchall():
-                self.cs_to_dbid[row[1]] = row[0]
+                cs_to_dbid[row[1]] = row[0]
         cur.close()
         self.conn.commit()
 

--- a/reposcan/database/update_store.py
+++ b/reposcan/database/update_store.py
@@ -36,8 +36,7 @@ class UpdateStore:
         to_associate = []
         for update in updates:
             update_id = update_map[update["id"]]
-            nevras = set([(pkg["name"], pkg["epoch"], pkg["ver"], pkg["rel"], pkg["arch"])
-                          for pkg in update["pkglist"]])
+            nevras = {(pkg["name"], pkg["epoch"], pkg["ver"], pkg["rel"], pkg["arch"]) for pkg in update["pkglist"]}
             for nevra in nevras:
                 if nevra not in nevras_in_repo:
                     self.logger.debug("NEVRA associated with %s not found in repository: (%s)",
@@ -231,7 +230,7 @@ class UpdateStore:
         to_associate = []
         for update in updates:
             update_id = update_map[update["id"]]
-            for cve in set([cve["id"] for cve in update["references"] if cve["type"] == "cve"]):
+            for cve in {cve["id"] for cve in update["references"] if cve["type"] == "cve"}:
                 cve_id = cve_map[cve]
                 if update_id in update_to_cves and cve_id in update_to_cves[update_id]:
                     # Already associated, remove from set

--- a/reposcan/download/downloader.py
+++ b/reposcan/download/downloader.py
@@ -14,9 +14,9 @@ from requests.exceptions import ConnectionError  # pylint: disable=redefined-bui
 
 from common.logging import get_logger
 
-DEFAULT_CHUNK_SIZE = 1048576
-DEFAULT_THREADS = 8
-DEFAULT_RETRY_COUNT = 3
+DEFAULT_CHUNK_SIZE = "1048576"
+DEFAULT_THREADS = "8"
+DEFAULT_RETRY_COUNT = "3"
 VALID_HTTP_CODES = [200]
 
 

--- a/reposcan/download/unpacker.py
+++ b/reposcan/download/unpacker.py
@@ -8,7 +8,7 @@ import bz2
 
 from common.logging import get_logger
 
-DEFAULT_CHUNK_SIZE = 1048576
+DEFAULT_CHUNK_SIZE = "1048576"
 
 
 
@@ -31,9 +31,9 @@ class FileUnpacker:
     def _get_unpack_func(file_path):
         if file_path.endswith(".gz"):
             return gzip.open
-        elif file_path.endswith(".xz"):
+        if file_path.endswith(".xz"):
             return lzma.open
-        elif file_path.endswith(".bz2"):
+        if file_path.endswith(".bz2"):
             return bz2.open
         return None
 

--- a/reposcan/nistcve/cve_controller.py
+++ b/reposcan/nistcve/cve_controller.py
@@ -16,7 +16,7 @@ from download.unpacker import FileUnpacker
 from nistcve.cvemeta import CveMeta
 from nistcve.cverepo import CveRepo
 
-DEFAULT_YEAR_SINCE = 2002
+DEFAULT_YEAR_SINCE = "2002"
 
 
 class CveRepoController:

--- a/reposcan/repodata/repository.py
+++ b/reposcan/repodata/repository.py
@@ -64,3 +64,9 @@ class Repository:
         """Unset previously loaded metadata files from this object."""
         self.primary = None
         self.updateinfo = None
+
+    def get_revision(self):
+        """Returns revision field of parsed repomd file if available."""
+        if self.repomd:
+            return self.repomd.get_revision()
+        return None

--- a/reposcan/repodata/repository_controller.py
+++ b/reposcan/repodata/repository_controller.py
@@ -148,8 +148,8 @@ class RepositoryController:
             self.certs_tmp_directory = None
             self.certs_files = {}
 
-    def add_synced_repositories(self):
-        """Queue all previously synced repositories."""
+    def add_db_repositories(self):
+        """Queue all previously imported repositories."""
         repos = self.repo_store.list_repositories()
         for (content_set, basearch, releasever), repo_dict in repos.items():
             # Reference content_set_label -> content set id
@@ -186,6 +186,12 @@ class RepositoryController:
                         self.certs_files[cert_name][cert_type] = cert_path
                     else:
                         self.certs_files[cert_name][cert_type] = None
+
+    def import_repositories(self):
+        """Create or update repository records in the DB."""
+        self.logger.info("Importing %d repositories.", len(self.repositories))
+        for repository in self.repositories:
+            self.repo_store.import_repository(repository)
 
     def store(self):
         """Sync all queued repositories. Process repositories in batches due to disk space and memory usage."""

--- a/reposcan/repodata/repository_controller.py
+++ b/reposcan/repodata/repository_controller.py
@@ -203,6 +203,7 @@ class RepositoryController:
         for content_set_label in self._find_content_sets_by_regex(content_set_regex):
             self.logger.info("Deleting content set: %s", content_set_label)
             self.repo_store.delete_content_set(content_set_label)
+        self.repo_store.cleanup_unused_data()
 
     def import_repositories(self):
         """Create or update repository records in the DB."""
@@ -251,4 +252,5 @@ class RepositoryController:
                 repository.unload_metadata()
             self.clean_repodata(batch)
 
+        self.repo_store.cleanup_unused_data()
         self._clean_certificate_cache()

--- a/reposcan/repodata/repository_controller.py
+++ b/reposcan/repodata/repository_controller.py
@@ -80,7 +80,7 @@ class RepositoryController:
                 repository.repomd = repomd
             else:
                 self.logger.info("Downloaded repo %s (%s) is not newer than repo in DB (%s).",
-                                 ", ".join(repository_key), str(downloaded_revision), str(db_revision))
+                                 ", ".join(filter(None, repository_key)), str(downloaded_revision), str(db_revision))
 
     def _repo_download_failed(self, repo, failed_items):
         failed = False

--- a/reposcan/repodata/repository_controller.py
+++ b/reposcan/repodata/repository_controller.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tempfile
 from urllib.parse import urljoin
+import re
 
 from common.batch_list import BatchList
 from common.logging import get_logger
@@ -186,6 +187,22 @@ class RepositoryController:
                         self.certs_files[cert_name][cert_type] = cert_path
                     else:
                         self.certs_files[cert_name][cert_type] = None
+
+    def _find_content_sets_by_regex(self, content_set_regex):
+        if not content_set_regex.startswith('^'):
+            content_set_regex = '^' + content_set_regex
+
+        if not content_set_regex.endswith('$'):
+            content_set_regex = content_set_regex + '$'
+
+        return [content_set_label for content_set_label in self.repo_store.content_set_to_db_id
+                if re.match(content_set_regex, content_set_label)]
+
+    def delete_content_set(self, content_set_regex):
+        """Deletes content sets described by given regex from DB."""
+        for content_set_label in self._find_content_sets_by_regex(content_set_regex):
+            self.logger.info("Deleting content set: %s", content_set_label)
+            self.repo_store.delete_content_set(content_set_label)
 
     def import_repositories(self):
         """Create or update repository records in the DB."""

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -204,7 +204,7 @@ class ExporterHandler(SyncHandler):
              429:
                description: Another sync is already in progress
            tags:
-             - sync
+             - export
         """
         status_code, status_msg = self.start_task()
         self.set_status(status_code)
@@ -592,10 +592,10 @@ class ReposcanApplication(Application):
             (r"/api/v1/apispec/?", ApiSpecHandler),
             (r"/api/v1/version/?", VersionHandler),
             (r"/api/v1/sync/?", AllSyncHandler),
-            (r"/api/v1/sync/export/?", ExporterHandler),
             (r"/api/v1/sync/repo/?", RepoSyncHandler),
             (r"/api/v1/sync/cve/?", CveSyncHandler),
             (r"/api/v1/sync/cvemap/?", CvemapSyncHandler),
+            (r"/api/v1/export/?", ExporterHandler),
         ]
         setup_apispec(handlers)
         Application.__init__(self, handlers)

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -366,7 +366,7 @@ class ExporterHandler(SyncHandler):
 
     task_type = "Export"
 
-    def get(self): # pylint: disable=arguments-differ
+    def put(self): # pylint: disable=arguments-differ
         """Export disk dump.
            ---
            description: Export disk dump
@@ -403,7 +403,7 @@ class RepoSyncHandler(SyncHandler):
 
     task_type = "Repo + %s" % ExporterHandler.task_type
 
-    def get(self): # pylint: disable=arguments-differ
+    def put(self): # pylint: disable=arguments-differ
         """Sync repositories stored in DB.
            ---
            description: Sync repositories stored in DB
@@ -444,7 +444,7 @@ class CveSyncHandler(SyncHandler):
 
     task_type = "CVE + %s" % ExporterHandler.task_type
 
-    def get(self): # pylint: disable=arguments-differ
+    def put(self): # pylint: disable=arguments-differ
         """Sync CVEs.
            ---
            description: Sync CVE lists
@@ -485,7 +485,7 @@ class CvemapSyncHandler(SyncHandler):
 
     task_type = "CVEmap + %s" % ExporterHandler.task_type
 
-    def get(self): # pylint: disable=arguments-differ
+    def put(self): # pylint: disable=arguments-differ
         """Sync CVEmap.
            ---
            description: Sync CVE map
@@ -528,7 +528,7 @@ class AllSyncHandler(SyncHandler):
                                        CveSyncHandler.task_type,
                                        ExporterHandler.task_type)
 
-    def get(self): # pylint: disable=arguments-differ
+    def put(self): # pylint: disable=arguments-differ
         """Sync repos + CVEs + CVEmap.
            ---
            description: Sync repositories stored in DB and CVE lists

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -424,6 +424,13 @@ class RepoDeleteHandler(SyncHandler):
         """Delete repository.
            ---
            description: Delete repository
+           parameters:
+             - name: repo
+               description: Repository name or POSIX regular expression pattern
+               required: True
+               type: string
+               in: path
+               x-example: rhel-6-server-rpms OR rhel-[4567]-.*-rpms OR rhel-\\d-server-rpms
            responses:
              200:
                description: Repository deletion started

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -156,11 +156,13 @@ class RepoListHandler(BaseHandler):
         # (repo_url, basearch, releasever)
         repos = [(baseurl, None, None)]
         # Replace basearch
-        repos = [(repo[0].replace("$basearch", basearch), basearch, repo[2])
-                 for basearch in basearches for repo in repos]
+        if basearches:
+            repos = [(repo[0].replace("$basearch", basearch), basearch, repo[2])
+                     for basearch in basearches for repo in repos]
         # Replace releasever
-        repos = [(repo[0].replace("$releasever", releasever), repo[1], releasever)
-                 for releasever in releasevers for repo in repos]
+        if releasevers:
+            repos = [(repo[0].replace("$releasever", releasever), repo[1], releasever)
+                     for releasever in releasevers for repo in repos]
 
         return repos
 

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -102,6 +102,7 @@ class BaseHandler(RequestHandler):
     def set_default_headers(self):
         self.set_header("Access-Control-Allow-Origin", "*")
         self.set_header("Access-Control-Allow-Headers", "Content-Type")
+        self.set_header("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE")
 
     def options(self): # pylint: disable=arguments-differ
         self.finish()

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -81,9 +81,10 @@ class NotificationHandler(WebSocketHandler):
 
 class TaskStatusResponse(dict):
     """Object used as API response to user."""
-    def __init__(self, running=False):
+    def __init__(self, running=False, task_type=None):
         super(TaskStatusResponse, self).__init__()
         self['running'] = running
+        self['task_type'] = task_type
 
 
 class TaskStartResponse(dict):
@@ -164,7 +165,7 @@ class TaskStatusHandler(BaseHandler):
            tags:
              - task
         """
-        self.write(TaskStatusResponse(running=SyncTask.is_running()))
+        self.write(TaskStatusResponse(running=SyncTask.is_running(), task_type=SyncTask.get_task_type()))
         self.flush()
 
 
@@ -186,7 +187,7 @@ class TaskCancelHandler(BaseHandler):
         if SyncTask.is_running():
             SyncTask.cancel()
             LOGGER.warning("Background task terminated.")
-        self.write(TaskStatusResponse(running=SyncTask.is_running()))
+        self.write(TaskStatusResponse(running=SyncTask.is_running(), task_type=SyncTask.get_task_type()))
         self.flush()
 
 
@@ -368,7 +369,7 @@ class RepoListHandler(BaseHandler):
 class SyncHandler(BaseHandler):
     """Base handler class providing common methods for different sync types."""
 
-    task_type = None
+    task_type = "Unknown"
 
     @classmethod
     def start_task(cls, *args, **kwargs):
@@ -376,7 +377,7 @@ class SyncHandler(BaseHandler):
         if not SyncTask.is_running():
             msg = "%s task started." % cls.task_type
             LOGGER.info(msg)
-            SyncTask.start(cls.run_task_and_export, cls.finish_task, *args, **kwargs)
+            SyncTask.start(cls.task_type, cls.run_task_and_export, cls.finish_task, *args, **kwargs)
             status_code = 200
             status_msg = TaskStartResponse(msg)
         else:
@@ -417,7 +418,7 @@ class SyncHandler(BaseHandler):
 class RepoDeleteHandler(SyncHandler):
     """Handler for repository item API."""
 
-    task_type = "Delete"
+    task_type = "Delete repositories"
 
     def delete(self, repo=None): # pylint: disable=arguments-differ
         """Delete repository.
@@ -457,7 +458,7 @@ class RepoDeleteHandler(SyncHandler):
 class ExporterHandler(SyncHandler):
     """Handler for Export API."""
 
-    task_type = "Export"
+    task_type = "Export dump"
 
     def put(self): # pylint: disable=arguments-differ
         """Export disk dump.
@@ -494,7 +495,7 @@ class ExporterHandler(SyncHandler):
 class RepoSyncHandler(SyncHandler):
     """Handler for repository sync API."""
 
-    task_type = "Repo"
+    task_type = "Sync repositories"
 
     def put(self): # pylint: disable=arguments-differ
         """Sync repositories stored in DB.
@@ -535,7 +536,7 @@ class RepoSyncHandler(SyncHandler):
 class CveSyncHandler(SyncHandler):
     """Handler for CVE sync API."""
 
-    task_type = "CVE"
+    task_type = "Sync CVEs"
 
     def put(self): # pylint: disable=arguments-differ
         """Sync CVEs.
@@ -576,7 +577,7 @@ class CveSyncHandler(SyncHandler):
 class CvemapSyncHandler(SyncHandler):
     """Handler for CVE sync API."""
 
-    task_type = "CVEmap"
+    task_type = "Sync CVE map"
 
     def put(self): # pylint: disable=arguments-differ
         """Sync CVEmap.
@@ -648,7 +649,8 @@ class AllSyncHandler(SyncHandler):
 
 def setup_apispec(handlers):
     """Setup definitions and handlers for apispec."""
-    SPEC.definition("TaskStatusResponse", properties={"running": {"type": "boolean"}})
+    SPEC.definition("TaskStatusResponse", properties={"running": {"type": "boolean"},
+                                                      "task_type": {"type": "string", "example": "Sync CVEs"}})
     SPEC.definition("TaskStartResponse", properties={"success": {"type": "boolean"},
                                                      "msg": {"type": "string", "example": "Repo sync task started."}})
     # Register public API handlers to apispec
@@ -663,12 +665,14 @@ class SyncTask:
     Limit to single DB worker.
     """
     _running = False
+    _running_task_type = None
     workers = Pool(1)
 
     @classmethod
-    def start(cls, func, callback, *args, **kwargs):
+    def start(cls, task_type, func, callback, *args, **kwargs):
         """Start specified function with given parameters in separate worker."""
         cls._running = True
+        cls._running_task_type = task_type
         ioloop = IOLoop.instance()
 
         def _callback(result):
@@ -679,11 +683,17 @@ class SyncTask:
     def finish(cls):
         """Mark work as done."""
         cls._running = False
+        cls._running_task_type = None
 
     @classmethod
     def is_running(cls):
         """Return True when some sync is running."""
         return cls._running
+
+    @classmethod
+    def get_task_type(cls):
+        """Get currently running task type."""
+        return cls._running_task_type
 
     @classmethod
     def cancel(cls):

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -591,6 +591,8 @@ class ReposcanApplication(Application):
             (r"/api/v1/monitoring/health/?", HealthHandler),
             (r"/api/v1/apispec/?", ApiSpecHandler),
             (r"/api/v1/version/?", VersionHandler),
+            (r"/api/v1/repos/?", RepoListHandler),
+            (r"/api/v1/repos/(?P<repo>[\\a-zA-Z0-9%*-.+?\[\]]+)", RepoDeleteHandler),
             (r"/api/v1/sync/?", AllSyncHandler),
             (r"/api/v1/sync/repo/?", RepoSyncHandler),
             (r"/api/v1/sync/cve/?", CveSyncHandler),

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -420,6 +420,9 @@ class RepoDeleteHandler(SyncHandler):
 
     task_type = "Delete repositories"
 
+    def options(self, repo=None): # pylint: disable=arguments-differ,unused-argument
+        self.finish()
+
     def delete(self, repo=None): # pylint: disable=arguments-differ
         """Delete repository.
            ---

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -748,7 +748,7 @@ def main():
     """Main entrypoint."""
     init_logging()
     LOGGER.info("Starting (version %s).", VMAAS_VERSION)
-    sync_interval = int(os.getenv('REPOSCAN_SYNC_INTERVAL_MINUTES', 720)) * 60000
+    sync_interval = int(os.getenv('REPOSCAN_SYNC_INTERVAL_MINUTES', "720")) * 60000
     if sync_interval > 0:
         PeriodicCallback(periodic_sync, sync_interval).start()
     else:

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -113,8 +113,6 @@ class HealthHandler(BaseHandler):
            responses:
              200:
                description: Application is alive
-           tags:
-             - monitoring
         """
         self.flush()
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -26,7 +26,7 @@ import gen
 
 VMAAS_VERSION = os.getenv("VMAAS_VERSION", "unknown")
 PUBLIC_API_PORT = 8080
-MAX_SERVERS = 1
+MAX_SERVERS = "1"
 
 SPEC = APISpec(
     title='VMaaS Webapp',

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -138,8 +138,6 @@ class HealthHandler(BaseHandler):
            responses:
              200:
                description: Application is alive
-           tags:
-             - monitoring
         """
         yield self.flush()
 

--- a/webapp/cache.py
+++ b/webapp/cache.py
@@ -49,7 +49,7 @@ ERRATA_URL = 12
 
 LOGGER = get_logger(__name__)
 
-class Cache(object):
+class Cache:
     """ Cache class. """
     # pylint: disable=too-many-instance-attributes
     def __init__(self, filename=DUMP):

--- a/webapp/cve.py
+++ b/webapp/cve.py
@@ -23,7 +23,7 @@ JSON_SCHEMA = {
 }
 
 
-class CveAPI(object):
+class CveAPI:
     """ Main /cves API class. """
     def __init__(self, cache):
         self.cache = cache

--- a/webapp/dbchange.py
+++ b/webapp/dbchange.py
@@ -4,7 +4,7 @@ Module contains functions for returning last-modified data from the DB
 
 from utils import format_datetime
 
-class DBChange(object):
+class DBChange:
     """ Main /dbchange API class. """
     def __init__(self, cache):
         self.cache = cache

--- a/webapp/errata.py
+++ b/webapp/errata.py
@@ -25,7 +25,7 @@ JSON_SCHEMA = {
 }
 
 
-class ErrataAPI(object):
+class ErrataAPI:
     """ Main /errata API class. """
     def __init__(self, cache):
         self.cache = cache

--- a/webapp/gen.py
+++ b/webapp/gen.py
@@ -7,7 +7,7 @@ from tornado.gen import coroutine as tornado_coroutine
 
 def coroutine(func, replace_callback=True):
     """Fixed coroutine annotation."""
-    wrapper = tornado_coroutine(func, replace_callback=replace_callback)
+    wrapper = tornado_coroutine(func, replace_callback=replace_callback) # pylint: disable=unexpected-keyword-arg
     wrapper.__wrapped__ = func
     wrapper.__tornado_coroutine__ = True
     return wrapper

--- a/webapp/repos.py
+++ b/webapp/repos.py
@@ -21,7 +21,7 @@ JSON_SCHEMA = {
 }
 
 
-class RepoAPI(object):
+class RepoAPI:
     """ Main /repos API class."""
     def __init__(self, cache):
         self.cache = cache

--- a/webapp/updates.py
+++ b/webapp/updates.py
@@ -25,7 +25,7 @@ JSON_SCHEMA = {
 }
 
 
-class CacheNode(object):
+class CacheNode:
     """Node of a binary tree"""
 
     def __init__(self, key, cached_response=None):
@@ -34,7 +34,7 @@ class CacheNode(object):
         self.left = self.right = None
 
 
-class HotCache(object):
+class HotCache:
     """Splay Tree implementaion, see https://en.wikipedia.org/wiki/Splay_tree for the details
 
         We use this tree to store cached data in nodes,
@@ -172,7 +172,7 @@ class HotCache(object):
             self._pruning(node.right, level=level + 1)
 
 
-class UpdatesAPI(object):
+class UpdatesAPI:
     """ Main /updates API class."""
     def __init__(self, db_cache):
         self.db_cache = db_cache      # DB dump in memory, stored like a dict


### PR DESCRIPTION
- fixes #22 
- fixes #293
- export API endpoint renamed (it's not sync)
- repository import and repository sync are now two separate steps
- fixed bug when repositories with empty basearch or releasever were ignored
- added support for removing repositories (using content sets labels)
- added support to get status and to cancel currently running background task
- all API endpoints changing database changed from GET to PUT