### PR TITLE
reposcan can occasionally take more memory and crash silently

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
           memory: 200M
         limits:
           cpus: '1.00'
-          memory: 1G
+          memory: 2G
 
   webapp:
     container_name: vmaas-webapp


### PR DESCRIPTION
this is a workaround, not a fix

to fix it it's necessary to fix #26 and correctly handle child process status when this crash happens (this causing a bug as kernel kills python worker subprocess and nothing is returned back to main python process - reposcan is stuck)