### PR TITLE
add helper script to remove all resource requirements from all deploy…

### DIFF
--- a/scripts/openshift-common.sh
+++ b/scripts/openshift-common.sh
@@ -43,8 +43,10 @@ for dc in $dcs; do
     containers=$(oc get dc/$dc -o json | python -c "import sys,json;obj=json.load(sys.stdin);containers=obj['spec']['template']['spec']['containers'];print(' '.join([c['name'] for c in containers]))" | wc -w)
     containers=$((containers-1))
     for i in $(seq 0 $containers); do
-	if ["$action" == "remove-resources"]; then
+	if [ "$action" == "remove-resources" ]; then
             oc patch dc/$dc --type json -p "[{\"op\": \"remove\", \"path\": \"/spec/template/spec/containers/$i/resources\"}]"
+	elif [ "$action" == "devel-container" ]; then
+	    oc patch dc/$dc --type json -p "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/$i/command\", \"value\": [\"sleep\", \"infinity\"]}]"
 	fi
     done
 done

--- a/scripts/openshift-common.sh
+++ b/scripts/openshift-common.sh
@@ -47,6 +47,7 @@ for dc in $dcs; do
             oc patch dc/$dc --type json -p "[{\"op\": \"remove\", \"path\": \"/spec/template/spec/containers/$i/resources\"}]"
 	elif [ "$action" == "devel-container" ]; then
 	    oc patch dc/$dc --type json -p "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/$i/command\", \"value\": [\"sleep\", \"infinity\"]}]"
+	    oc patch dc/$dc --type json -p "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/$i/securityContext\", \"value\": {\"runAsUser\": '0'}}]"
 	fi
     done
 done

--- a/scripts/openshift-common.sh
+++ b/scripts/openshift-common.sh
@@ -1,0 +1,53 @@
+current_user=$(oc whoami 2> /dev/null)
+
+if [ "$current_user" == "" ]; then
+    echo "Please login to OpenShift cluster and select project."
+    exit 1
+fi
+
+filter="$2"
+if [ "$filter" != "" ]; then
+    dcs=$(oc get dc 2> /dev/null | tail -n +2 | awk '{print $1}' | grep "$filter")
+else
+    dcs=$(oc get dc 2> /dev/null | tail -n +2 | awk '{print $1}')
+fi
+
+echo "$(oc project)"
+echo "Logged in as user \"$current_user\"."
+echo ""
+if [ "$dcs" == "" ]; then
+    echo "No deployment configs found in project. Exiting."
+    exit 2
+fi
+
+warning="$warning"
+echo "$warning"
+
+for dc in $dcs; do
+    echo "$dc"
+done
+echo ""
+echo -n "Continue? [y/N] "
+
+read choice
+choice=$(echo $choice | awk '{print toupper($0)}')
+
+if [ "$choice" != "Y" ]; then
+    echo "Exiting."
+    exit 3
+fi
+
+action="$3"
+
+for dc in $dcs; do
+    containers=$(oc get dc/$dc -o json | python -c "import sys,json;obj=json.load(sys.stdin);containers=obj['spec']['template']['spec']['containers'];print(' '.join([c['name'] for c in containers]))" | wc -w)
+    containers=$((containers-1))
+    for i in $(seq 0 $containers); do
+	if ["$action" == "remove-resources"]; then
+            oc patch dc/$dc --type json -p "[{\"op\": \"remove\", \"path\": \"/spec/template/spec/containers/$i/resources\"}]"
+	fi
+    done
+done
+
+echo ""
+echo "Done."

--- a/scripts/openshift-devel-container.sh
+++ b/scripts/openshift-devel-container.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+
+warning="WARNING: This script will OVERRIDE container entrypoint of following deployment configs:"
+filter="$1"
+
+. ./openshift-common.sh "$warning" "$filter" "devel-container"
+

--- a/scripts/openshift-remove-required-resources.sh
+++ b/scripts/openshift-remove-required-resources.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+
+warning="WARNING: This script will REMOVE resource requests/limits from ALL deployment configs in current project:"
+filter="$1"
+
+. ./openshift-common.sh "$warning" "$filter" "remove-resources"
+


### PR DESCRIPTION
…ment configs in current project

Our openshift templates are using resource requests/limits for each service, this is good for production but when deploying in local openshift cluster like minishift, you may not be able (and you typically don't need to) to allocate so much resources, this script will remove all resource requirements from currently selected project.