### PR TITLE
remove duplicated env variable setting

### DIFF
--- a/apidoc/Dockerfile
+++ b/apidoc/Dockerfile
@@ -1,7 +1,5 @@
 FROM swaggerapi/swagger-ui:v3.13.2
 
-ENV API_URLS="[{url:'http://localhost:8080/api/v1/apispec', name:'webapp'},{url:'http://localhost:8081/api/v1/apispec', name:'reposcan'}]"
-
 RUN chmod g+w,o+w /etc/nginx/ /usr/share/nginx/html/ /var/log/nginx/ /run/nginx/ \
     && chmod o+rx /var/lib/nginx/ \
     && chmod g+rwx,o+rwx /var/lib/nginx/tmp/


### PR DESCRIPTION
API_URLS env variable was both defined in Dockerfile and conf/apidoc.env