### PR TITLE
process modular updates

### DIFF
--- a/reposcan/exporter.py
+++ b/reposcan/exporter.py
@@ -336,25 +336,16 @@ class DataDump:
     def dump_modules(self, dump):
         """Select module information"""
         with self._named_cursor() as cursor:
-            if self.errata_ids:
-                cursor.execute("""select pkg_id,
-                                         module_stream_id as module_id
-                                    from pkg_errata
-                                   where module_stream_id is not null
-                                     and errata_id in %s
-                                   union
-                                  select pkg_id,
-                                         stream_id as module_id
-                                    from module_rpm_artifact
-                            """, [tuple(self.errata_ids)])
-            else:
-                cursor.execute("""select pkg_id,
-                                         stream_id as module_id
-                                    from module_rpm_artifact
-                               """)
+            cursor.execute("""select pkg_id,
+                                     errata_id,
+                                     module_stream_id as module_id
+                                from pkg_errata
+                               where module_stream_id is not null
+                                 and errata_id in %s
+                        """, [tuple(self.errata_ids)])
             pkg2module = {}
-            for pkg_id, module_id in cursor:
-                pkg2module.setdefault("pkg2module:%s" % pkg_id, set()).add(module_id)
+            for pkg_id, errata_id, module_id in cursor:
+                pkg2module.setdefault("pkgerrata2module:%s:%s" % (pkg_id, errata_id), set()).add(module_id)
             dump.update(pkg2module)
 
         with self._named_cursor() as cursor:

--- a/reposcan/exporter.py
+++ b/reposcan/exporter.py
@@ -335,18 +335,19 @@ class DataDump:
 
     def dump_modules(self, dump):
         """Select module information"""
-        with self._named_cursor() as cursor:
-            cursor.execute("""select pkg_id,
-                                     errata_id,
-                                     module_stream_id as module_id
-                                from pkg_errata
-                               where module_stream_id is not null
-                                 and errata_id in %s
-                        """, [tuple(self.errata_ids)])
-            pkg2module = {}
-            for pkg_id, errata_id, module_id in cursor:
-                pkg2module.setdefault("pkgerrata2module:%s:%s" % (pkg_id, errata_id), set()).add(module_id)
-            dump.update(pkg2module)
+        if self.errata_ids:
+            with self._named_cursor() as cursor:
+                cursor.execute("""select pkg_id,
+                                         errata_id,
+                                         module_stream_id as module_id
+                                    from pkg_errata
+                                   where module_stream_id is not null
+                                     and errata_id in %s
+                            """, [tuple(self.errata_ids)])
+                pkg2module = {}
+                for pkg_id, errata_id, module_id in cursor:
+                    pkg2module.setdefault("pkgerrata2module:%s:%s" % (pkg_id, errata_id), set()).add(module_id)
+                dump.update(pkg2module)
 
         with self._named_cursor() as cursor:
             cursor.execute("""select m.name,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -269,6 +269,17 @@ class UpdatesHandlerPost(BaseHandler):
                   items:
                     type: string
                     example: rhel-6-server-rpms
+                modules_list:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      module_name:
+                        type: string
+                        example: rhn-tools
+                      module_stream:
+                        type: string
+                        example: 1.0
                 releasever:
                   type: string
                   example: 6Server
@@ -342,6 +353,17 @@ class UpdatesHandlerV2Post(BaseHandler):
                   items:
                     type: string
                     example: rhel-6-server-rpms
+                modules_list:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      module_name:
+                        type: string
+                        example: rhn-tools
+                      module_stream:
+                        type: string
+                        example: 1.0
                 releasever:
                   type: string
                   example: 6Server

--- a/webapp/cache.py
+++ b/webapp/cache.py
@@ -84,7 +84,7 @@ class Cache:
         self.pkgid2errataids = {}
         self.errataid2repoids = {}
         self.cve_detail = {}
-        self.pkg2module = {}
+        self.pkgerrata2module = {}
         self.modulename2id = {}
         self.dbchange = {}
         self.errata_detail = {}
@@ -155,8 +155,9 @@ class Cache:
                 self.dbchange[key] = data[item]
             elif relation == "errata_detail":
                 self.errata_detail[key] = data[item]
-            elif relation == "pkg2module":
-                self.pkg2module[int(key)] = data[item]
+            elif relation == "pkgerrata2module":
+                pkg_id, errata_id = key.split(":", 1)
+                self.pkgerrata2module[(int(pkg_id), int(errata_id))] = data[item]
             elif relation == "modulename2id":
                 name, stream_name = key.split(":", 1)
                 self.modulename2id[(name, stream_name)] = data[item]


### PR DESCRIPTION
This PR addresses modularity updates and modular erratas.
There's a new parameter added to the POST /updates API called modules_list (see SwaggerUI), which serves as constraint to the updates search.
Without "modules_list" the /updates API returns every possible update, with no regards to enabled modules (it will offer package from other stream as an update if it has higher NEVRA).
With "modules_list" parameter present, but empty, the /updates API expects that no modules are enabled and will discard all modular erratas.
When "modules_list" is present and NOT empty, /updates API will show modular updates coming only from modules in the "modules_list" and all non-modular updates as well.