### PR TITLE
store new module versions introduced by erratas into database

### DIFF
--- a/reposcan/database/modules_store.py
+++ b/reposcan/database/modules_store.py
@@ -35,20 +35,20 @@ class ModulesStore(ObjectStore):
         module_map = {}
         arch_map = self._prepare_arch_map()
         for module in modules:
-            names.add((module['name'], arch_map[module['arch']],))
+            names.add((module['name'], arch_map[module['arch']], repo_id))
         if names:
             execute_values(cur,
-                           """select id, name, arch_id from module
-                              inner join (values %s) t(name, arch_id)
-                              using (name, arch_id)
+                           """select id, name, arch_id, repo_id from module
+                              inner join (values %s) t(name, arch_id, repo_id)
+                              using (name, arch_id, repo_id)
                            """, list(names), page_size=len(names))
             for row in cur.fetchall():
                 module_map[(row[1], row[2],)] = row[0]
-                names.remove((row[1], row[2],))
+                names.remove((row[1], row[2], row[3]))
         if names:
             import_data = set()
             for module in modules:
-                if (module['name'], arch_map[module['arch']],) in names:
+                if (module['name'], arch_map[module['arch']], repo_id) in names:
                     import_data.add((module['name'], repo_id, arch_map[module['arch']]))
             execute_values(cur,
                            """insert into module (name, repo_id, arch_id)

--- a/reposcan/database/modules_store.py
+++ b/reposcan/database/modules_store.py
@@ -197,6 +197,13 @@ class ModulesStore(ObjectStore):
         cur.close()
         self.conn.commit()
 
+    def create_module(self, repo_id, module):
+        """Creates a new module stream (used for new module N:S:V:C introduced in errata)"""
+        module['default_stream'] = False
+        modules = self._populate_modules(repo_id, [module])
+        modules = self._populate_streams(modules)
+        return modules[0]
+
     def store(self, repo_id, modules):
         """Import all modules from repository into all related DB tables."""
 


### PR DESCRIPTION
Erratas may introduce new version of module when the version or context changes. Store these different N:S:V:Cs into database.