### PR TITLE
catch missing parts of module info during json schema validation

### DIFF
--- a/webapp/updates.py
+++ b/webapp/updates.py
@@ -24,6 +24,7 @@ JSON_SCHEMA = {
             'type': 'array',
             'items': {
                 'type': 'object',
+                'required': ['module_name', 'module_stream'],
                 'properties': {
                     'module_name': {'type': 'string'},
                     'module_stream': {'type': 'string'}


### PR DESCRIPTION
vmaas-webapp       | f44bdb3ffc28 2019-04-04 08:13:25,084 __main__: [ERROR] Internal server error <-9223363243124068951>: please include this error id in bug report.'Traceback (most recent call last):\n  File "/webapp/app.py", line 105, in handle_post\n    res = api_endpoint.process_list(api_version, data)\n  File "/webapp/updates.py", line 381, in process_list\n    module_info = [(x[\'module_name\'], x[\'module_stream\']) for x in modules_list]\n  File "/webapp/updates.py", line 381, in <listcomp>\n    module_info = [(x[\'module_name\'], x[\'module_stream\']) for x in modules_list]\nKeyError: \'module_stream\''|
vmaas-webapp       | f44bdb3ffc28 2019-04-04 08:13:25,084 __main__: [INFO] Input data for <-9223363243124068951>: {'package_list': ['postgresql-9.6.10-1.el8+1547+210b7007.x86_64.rpm'], 'modules_list': [{'module_name': 'postgresql'}]}