### PR TITLE
 reduce number of intermediate Docker images after code change 

### DIFF
--- a/Dockerfile-reposcan
+++ b/Dockerfile-reposcan
@@ -11,6 +11,15 @@ RUN yum -y update \
 
 ENV APPBASEDIR=/reposcan
 
+ADD scl-enable.sh $APPBASEDIR/
+
+RUN install -d -m 775 -g root /data
+RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'VMAAS user' vmaas
+
+RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
+
+RUN $APPBASEDIR/scl-enable.sh pip install prometheus-client psycopg2-binary tornado requests "apispec==0.39.0" python-dateutil
+
 # copy application to directory in a container
 ADD $APPBASEDIR/*.sh $APPBASEDIR/
 ADD $APPBASEDIR/*.py $APPBASEDIR/
@@ -21,14 +30,6 @@ ADD $APPBASEDIR/nistcve/*.py $APPBASEDIR/nistcve/
 ADD $APPBASEDIR/redhatcve/*.py $APPBASEDIR/redhatcve/
 ADD $APPBASEDIR/repodata/*.py $APPBASEDIR/repodata/
 ADD $APPBASEDIR/rsyncd.conf /etc/
-ADD scl-enable.sh $APPBASEDIR/
-
-RUN install -d -m 775 -g root /data
-RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'VMAAS user' vmaas
-
-RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
-
-RUN $APPBASEDIR/scl-enable.sh pip install prometheus-client psycopg2-binary tornado requests "apispec==0.39.0" python-dateutil
 
 USER vmaas
 

--- a/Dockerfile-reposcan.rhel7
+++ b/Dockerfile-reposcan.rhel7
@@ -11,6 +11,15 @@ RUN yum -y update \
 
 ENV APPBASEDIR=/reposcan
 
+ADD scl-enable.sh $APPBASEDIR/
+
+RUN install -d -m 775 -g root /data
+RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'VMAAS user' vmaas
+
+RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
+
+RUN $APPBASEDIR/scl-enable.sh pip install prometheus-client psycopg2-binary tornado requests "apispec==0.39.0" python-dateutil
+
 # copy application to directory in a container
 ADD $APPBASEDIR/*.sh $APPBASEDIR/
 ADD $APPBASEDIR/*.py $APPBASEDIR/
@@ -21,14 +30,6 @@ ADD $APPBASEDIR/nistcve/*.py $APPBASEDIR/nistcve/
 ADD $APPBASEDIR/redhatcve/*.py $APPBASEDIR/redhatcve/
 ADD $APPBASEDIR/repodata/*.py $APPBASEDIR/repodata/
 ADD $APPBASEDIR/rsyncd.conf /etc/
-ADD scl-enable.sh $APPBASEDIR/
-
-RUN install -d -m 775 -g root /data
-RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'VMAAS user' vmaas
-
-RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
-
-RUN $APPBASEDIR/scl-enable.sh pip install prometheus-client psycopg2-binary tornado requests "apispec==0.39.0" python-dateutil
 
 USER vmaas
 

--- a/Dockerfile-webapp
+++ b/Dockerfile-webapp
@@ -12,8 +12,6 @@ RUN yum -y update \
 ENV APPBASEDIR=/webapp
 
 RUN install -m 1777 -d /data
-ADD $APPBASEDIR/*.sh $APPBASEDIR/
-ADD $APPBASEDIR/*.py $APPBASEDIR/
 ADD scl-enable.sh $APPBASEDIR/
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'VMAAS user' vmaas
@@ -21,6 +19,9 @@ RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'VMAAS user' vmaas
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
 RUN $APPBASEDIR/scl-enable.sh pip install tornado "apispec==0.39.0" psycopg2-binary python-dateutil jsonschema prometheus_client
+
+ADD $APPBASEDIR/*.sh $APPBASEDIR/
+ADD $APPBASEDIR/*.py $APPBASEDIR/
 
 USER vmaas
 

--- a/Dockerfile-webapp-qe
+++ b/Dockerfile-webapp-qe
@@ -12,8 +12,6 @@ RUN yum -y update \
 ENV APPBASEDIR=/webapp
 
 RUN install -m 1777 -d /data
-ADD $APPBASEDIR/*.sh $APPBASEDIR/
-ADD $APPBASEDIR/*.py $APPBASEDIR/
 ADD scl-enable.sh $APPBASEDIR/
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'VMAAS user' vmaas
@@ -21,6 +19,9 @@ RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'VMAAS user' vmaas
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
 RUN $APPBASEDIR/scl-enable.sh pip install tornado "apispec==0.39.0" psycopg2-binary python-dateutil jsonschema prometheus_client coverage
+
+ADD $APPBASEDIR/*.sh $APPBASEDIR/
+ADD $APPBASEDIR/*.py $APPBASEDIR/
 
 USER vmaas
 

--- a/Dockerfile-webapp.rhel7
+++ b/Dockerfile-webapp.rhel7
@@ -12,8 +12,6 @@ RUN yum -y update \
 ENV APPBASEDIR=/webapp
 
 RUN install -m 1777 -d /data
-ADD $APPBASEDIR/*.sh $APPBASEDIR/
-ADD $APPBASEDIR/*.py $APPBASEDIR/
 ADD scl-enable.sh $APPBASEDIR/
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'VMAAS user' vmaas
@@ -21,6 +19,9 @@ RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'VMAAS user' vmaas
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
 RUN $APPBASEDIR/scl-enable.sh pip install tornado "apispec==0.39.0" psycopg2-binary python-dateutil jsonschema prometheus_client
+
+ADD $APPBASEDIR/*.sh $APPBASEDIR/
+ADD $APPBASEDIR/*.py $APPBASEDIR/
 
 USER vmaas
 

--- a/Dockerfile-websocket
+++ b/Dockerfile-websocket
@@ -7,7 +7,6 @@ RUN yum -y update \
 
 ENV APPBASEDIR=/websocket
 
-ADD $APPBASEDIR/*.py $APPBASEDIR/
 ADD scl-enable.sh $APPBASEDIR/
 
 RUN adduser --gid 0 -d /app --no-create-home -c 'VMAAS user' vmaas
@@ -15,6 +14,8 @@ RUN adduser --gid 0 -d /app --no-create-home -c 'VMAAS user' vmaas
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
 RUN $APPBASEDIR/scl-enable.sh pip install tornado
+
+ADD $APPBASEDIR/*.py $APPBASEDIR/
 
 USER vmaas
 

--- a/Dockerfile-websocket.rhel7
+++ b/Dockerfile-websocket.rhel7
@@ -7,7 +7,6 @@ RUN yum -y update \
 
 ENV APPBASEDIR=/websocket
 
-ADD $APPBASEDIR/*.py $APPBASEDIR/
 ADD scl-enable.sh $APPBASEDIR/
 
 RUN adduser --gid 0 -d /app --no-create-home -c 'VMAAS user' vmaas
@@ -15,6 +14,8 @@ RUN adduser --gid 0 -d /app --no-create-home -c 'VMAAS user' vmaas
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
 RUN $APPBASEDIR/scl-enable.sh pip install tornado
+
+ADD $APPBASEDIR/*.py $APPBASEDIR/
 
 USER vmaas
 


### PR DESCRIPTION
Previously we were adding our code before running e.g. pip install or other things which are changing less often and have bigger layers than our code.
I've restructured the Dockerfiles in a way that things that are changing the least and take the biggest amount of time are run first, and our code is added at last possible place so we won't run whole `pip install --upgrade && pip install $LOT_OF_STUFF` after one line of code gets changed.