### PR TITLE
Fix traceback when importing repos w/modules and without at the same …

### DIFF
--- a/reposcan/database/package_store.py
+++ b/reposcan/database/package_store.py
@@ -106,6 +106,7 @@ class PackageStore(ObjectStore):
         cur = self.conn.cursor()
         self.logger.debug("Unique package names in repository: %d", len(unique_names))
         to_import = []
+        self.package_name_map = self._prepare_package_name_map()
         for name in unique_names:
             if name not in self.package_name_map:
                 to_import.append((name,))


### PR DESCRIPTION
…time

Import creates known-package-map at startup and assumes nothing can change it inside a single run.
Modularity-related code violates that assumption.

Teach package_store to not rely on __init__-time processing so much.