### PR TITLE
don't instantiate new UpdatesAPI each call

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1239,7 +1239,7 @@ def main():
     BaseHandler.cve_api = CveAPI(BaseHandler.db_cache)
     BaseHandler.errata_api = ErrataAPI(BaseHandler.db_cache)
     BaseHandler.packages_api = PackagesAPI(BaseHandler.db_cache)
-    BaseHandler.vulnerabilities_api = VulnerabilitiesAPI(BaseHandler.db_cache)
+    BaseHandler.vulnerabilities_api = VulnerabilitiesAPI(BaseHandler.db_cache, BaseHandler.updates_api)
     BaseHandler.dbchange_api = DBChange(BaseHandler.db_cache)
 
     vmaas_app.websocket_reconnect()

--- a/webapp/test/test_vulnerabilities.py
+++ b/webapp/test/test_vulnerabilities.py
@@ -7,6 +7,7 @@ from test.conftest import TestBase
 
 import pytest
 
+from updates import UpdatesAPI
 from vulnerabilities import VulnerabilitiesAPI
 
 PKG = "bash-0:4.2.46-20.el7_2.x86_64"
@@ -31,7 +32,7 @@ class TestVulnerabilitiesAPI(TestBase):
     @pytest.fixture(autouse=True)
     def setup_api(self, load_cache):
         """Setup UpdatesAPI object."""
-        self.vulnerabilities_api = VulnerabilitiesAPI(self.cache)
+        self.vulnerabilities_api = VulnerabilitiesAPI(self.cache, UpdatesAPI(self.cache))
 
     def test_schema(self):
         """Test schema of vulnerabilities api."""

--- a/webapp/vulnerabilities.py
+++ b/webapp/vulnerabilities.py
@@ -3,18 +3,18 @@ Module to handle /vulnerabilities API calls.
 """
 
 from cache import ERRATA_CVE
-from updates import UpdatesAPI
 
 
 class VulnerabilitiesAPI:
     """Main /vulnerabilities API class"""
 
-    def __init__(self, db_cache):
+    def __init__(self, db_cache, updates_api):
         self.db_cache = db_cache
+        self.updates_api = updates_api
 
     def process_list(self, api_version, data):  # pylint: disable=unused-argument
         """Return list of potential security issues"""
-        updates = UpdatesAPI(self.db_cache).process_list(2, data)
+        updates = self.updates_api.process_list(2, data)
         errata_list = set()
         cve_list = set()
         for package in updates['update_list']:


### PR DESCRIPTION
by instantiating a new object each call all caching was made useles as after one API call the cached things were garbage collected