### PR TITLE
get rid of package checksum

### DIFF
--- a/database/vmaas_db_postgresql.sql
+++ b/database/vmaas_db_postgresql.sql
@@ -171,16 +171,6 @@ CREATE TABLE IF NOT EXISTS evr (
 
 
 -- -----------------------------------------------------
--- Table vmaas.checksum_type
--- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS checksum_type (
-  id SERIAL,
-  name TEXT NOT NULL UNIQUE, CHECK (NOT empty(name)),
-  PRIMARY KEY (id)
-)TABLESPACE pg_default;
-
-
--- -----------------------------------------------------
 -- Table vmaas.arch
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS arch (
@@ -407,11 +397,9 @@ CREATE TABLE IF NOT EXISTS package (
   name_id INT NOT NULL,
   evr_id INT NOT NULL,
   arch_id INT NOT NULL,
-  checksum TEXT NOT NULL, CHECK (NOT empty(checksum)),
-  checksum_type_id INT NOT NULL,
   summary TEXT NULL, CHECK (NOT empty(summary)),
   description TEXT NULL, CHECK (NOT empty(description)),
-  UNIQUE (checksum_type_id, checksum),
+  UNIQUE (name_id, evr_id, arch_id),
   PRIMARY KEY (id),
   CONSTRAINT name_id
     FOREIGN KEY (name_id)
@@ -421,10 +409,7 @@ CREATE TABLE IF NOT EXISTS package (
     REFERENCES evr (id),
   CONSTRAINT arch_id
     FOREIGN KEY (arch_id)
-    REFERENCES arch (id),
-  CONSTRAINT checksum_type_id
-    FOREIGN KEY (checksum_type_id)
-    REFERENCES checksum_type (id)
+    REFERENCES arch (id)
 )TABLESPACE pg_default;
 
 CREATE INDEX ON package(name_id);

--- a/reposcan/database/modules_store.py
+++ b/reposcan/database/modules_store.py
@@ -14,7 +14,7 @@ class ModulesStore(ObjectStore):
         cur = self.conn.cursor()
         names = set()
         module_map = {}
-        arch_map = self._prepare_arch_map()
+        arch_map = self._prepare_table_map(["name"], "arch")
         for module in modules:
             names.add((module['name'], arch_map[module['arch']], repo_id))
         if names:

--- a/reposcan/database/package_store.py
+++ b/reposcan/database/package_store.py
@@ -79,7 +79,6 @@ class PackageStore(ObjectStore):
         cur = self.conn.cursor()
         self.logger.debug("Unique package names in repository: %d", len(unique_names))
         to_import = []
-        self.package_name_map = self._prepare_table_map(["name"], "package_name")
         for name in unique_names:
             if name not in self.package_name_map:
                 to_import.append((name,))

--- a/reposcan/database/package_store.py
+++ b/reposcan/database/package_store.py
@@ -21,37 +21,21 @@ class PackageStore(ObjectStore):
         self.package_name_map = self._prepare_table_map(cols=["name"], table="package_name")
         self.package_map = self._prepare_table_map(cols=["checksum_type_id", "checksum"], table="package")
 
-    def _populate_archs(self, unique_archs):
+    def _populate_dep_table(self, table, unique_items, table_map):
+        """Populate dependency table with column 'name'."""
         cur = self.conn.cursor()
-        self.logger.debug("Unique architectures in repository: %d", len(unique_archs))
+        self.logger.debug("Unique %s's in repository: %d", table, len(unique_items))
         to_import = []
-        for name in unique_archs:
-            if name not in self.arch_map:
-                to_import.append((name,))
+        for row in unique_items:
+            if row not in table_map:
+                to_import.append((row, ))
 
-        self.logger.debug("Architectures to import: %d", len(to_import))
+        self.logger.debug("%s's to import: %d", table, len(to_import))
         if to_import:
-            execute_values(cur, "insert into arch (name) values %s returning id, name",
-                           to_import, page_size=len(to_import))
-            for arch_id, name in cur.fetchall():
-                self.arch_map[name] = arch_id
-        cur.close()
-        self.conn.commit()
-
-    def _populate_checksum_types(self, unique_checksum_types):
-        cur = self.conn.cursor()
-        self.logger.debug("Unique checksum types in repository: %d", len(unique_checksum_types))
-        to_import = []
-        for name in unique_checksum_types:
-            if name not in self.checksum_type_map:
-                to_import.append((name,))
-
-        self.logger.debug("Checksum types to import: %d", len(to_import))
-        if to_import:
-            execute_values(cur, "insert into checksum_type (name) values %s returning id, name",
-                           to_import, page_size=len(to_import))
-            for ct_id, name in cur.fetchall():
-                self.checksum_type_map[name] = ct_id
+            sql = "insert into %s (name) values %%s returning id, name" % table
+            execute_values(cur, sql, to_import, page_size=len(to_import))
+            for row in cur.fetchall():
+                table_map[row[1]] = row[0]
         cur.close()
         self.conn.commit()
 
@@ -75,24 +59,6 @@ class PackageStore(ObjectStore):
         cur.close()
         self.conn.commit()
 
-    def _populate_package_names(self, unique_names):
-        cur = self.conn.cursor()
-        self.logger.debug("Unique package names in repository: %d", len(unique_names))
-        to_import = []
-        for name in unique_names:
-            if name not in self.package_name_map:
-                to_import.append((name,))
-
-        self.logger.debug("Package names to import: %d", len(to_import))
-        if to_import:
-            execute_values(cur,
-                           """insert into package_name (name) values %s returning id, name""",
-                           to_import, page_size=len(to_import))
-            for name_id, name in cur.fetchall():
-                self.package_name_map[name] = name_id
-        cur.close()
-        self.conn.commit()
-
     def _populate_dependent_tables(self, packages):
         unique_archs = set()
         unique_checksum_types = set()
@@ -105,10 +71,11 @@ class PackageStore(ObjectStore):
             unique_checksum_types.add(pkg["checksum_type"])
             unique_evrs.add((pkg["epoch"], pkg["ver"], pkg["rel"]))
             unique_names.add(pkg["name"])
-        self._populate_archs(unique_archs)
-        self._populate_checksum_types(unique_checksum_types)
+
+        self._populate_dep_table("arch", unique_archs, self.arch_map)
+        self._populate_dep_table("checksum_type", unique_checksum_types, self.checksum_type_map)
+        self._populate_dep_table("package_name", unique_names, self.package_name_map)
         self._populate_evrs(unique_evrs)
-        self._populate_package_names(unique_names)
 
     def _populate_packages(self, packages):
         self._populate_dependent_tables(packages)

--- a/reposcan/repodata/primary.py
+++ b/reposcan/repodata/primary.py
@@ -30,9 +30,6 @@ class PrimaryMD:
                     package["arch"] = text_strip(elem.find("primary:arch", NS))
                     package["summary"] = text_strip(elem.find("primary:summary", NS))
                     package["description"] = text_strip(elem.find("primary:description", NS))
-                    checksum = elem.find("primary:checksum", NS)
-                    package["checksum_type"] = checksum.get("type")
-                    package["checksum"] = text_strip(checksum)
                     self.packages.append(package)
                     # Clear the XML tree continuously
                     root.clear()

--- a/reposcan/repodata/primary_db.py
+++ b/reposcan/repodata/primary_db.py
@@ -13,7 +13,7 @@ class PrimaryDatabaseMD:
         cur = conn.cursor()
         sql = """
             select name, epoch, version, release, arch,
-                   summary, description, checksum_type, pkgid
+                   summary, description
               from packages"""
         for row in cur.execute(sql):
             self.packages.append({
@@ -23,9 +23,7 @@ class PrimaryDatabaseMD:
                 "rel": row["release"],
                 "arch": row["arch"],
                 "summary": row["summary"],
-                "description": row["description"],
-                "checksum_type": row["checksum_type"],
-                "checksum": row["pkgid"]
+                "description": row["description"]
             })
         conn.close()
 

--- a/reposcan/repodata/test/test_primary.py
+++ b/reposcan/repodata/test/test_primary.py
@@ -13,7 +13,7 @@ class TestPrimaryMD(unittest.TestCase):
         self.primary = PrimaryMD("test_data/repodata/primary.xml")
 
     def _test_package(self, pkg):
-        intended_fields = ["name", "epoch", "ver", "rel", "arch", "summary", "description", "checksum_type", "checksum"]
+        intended_fields = ["name", "epoch", "ver", "rel", "arch", "summary", "description"]
         actual_fields = pkg.keys()
         for field in intended_fields:
             self.assertTrue(field in actual_fields)

--- a/reposcan/test_data/exporter/exporter_test_data.sql
+++ b/reposcan/test_data/exporter/exporter_test_data.sql
@@ -12,17 +12,14 @@ INSERT INTO evr (id, epoch, version, release, evr) VALUES
   (205, '3', '3', '3', ('3', rpmver_array('3'), rpmver_array('3'))),
   (206, '4', '4', '4', ('4', rpmver_array('4'), rpmver_array('4')));
 
-INSERT INTO checksum_type (id, name) VALUES
-  (1, 'sha1');
-
-INSERT INTO package (id, name_id, evr_id, arch_id, checksum, checksum_type_id, summary, description) VALUES
-  (301, 101, 201, 1, 'checksum1', 1, 'summary1', 'description1'),
-  (302, 101, 202, 1, 'checksum2', 1, 'summary1', 'description1'),
-  (303, 101, 203, 1, 'checksum3', 1, 'summary1', 'description1'),
-  (304, 102, 204, 1, 'checksum4', 1, 'summary2', 'description2'),
-  (305, 103, 205, 1, 'checksum5', 1, 'summary3', 'description3'),
-  (306, 103, 206, 1, 'checksum6', 1, 'summary3', 'description3'),
-  (307, 104, 204, 1, 'checksum7', 1, 'summary4', 'description4');
+INSERT INTO package (id, name_id, evr_id, arch_id, summary, description) VALUES
+  (301, 101, 201, 1, 'summary1', 'description1'),
+  (302, 101, 202, 1, 'summary1', 'description1'),
+  (303, 101, 203, 1, 'summary1', 'description1'),
+  (304, 102, 204, 1, 'summary2', 'description2'),
+  (305, 103, 205, 1, 'summary3', 'description3'),
+  (306, 103, 206, 1, 'summary3', 'description3'),
+  (307, 104, 204, 1, 'summary4', 'description4');
 
 INSERT INTO errata_type (id, name) VALUES
   (1, 'security'),


### PR DESCRIPTION
- currently single package NEVRA can be stored in package table multiple times when it's available from different repos - based on checksum used in each repo (some use sha1, some sha256)
- however vmaas doesn't expose checksum anywhere, neither vmaas works with binary packages, I think we can safely remove package checksums
- each NEVRA will be unique in package table