### PR TITLE
source_package_id needs to be extracted

### DIFF
--- a/webapp/test/test_updates.py
+++ b/webapp/test/test_updates.py
@@ -59,7 +59,7 @@ class TestUpdatesAPI(TestBase):
         """Test repos processing."""
         response = {}
         repo_ids = self.updates_api._process_repositories(UPDATES_JSON, response)
-        assert repo_ids == {1}
+        assert len(repo_ids) == 1
 
     def test_process_repos_repo(self):
         """Test repos processing - filter out repository_list."""

--- a/webapp/test/test_utils.py
+++ b/webapp/test/test_utils.py
@@ -26,7 +26,7 @@ class TestUtils(TestBase):
     # load_cache is pytest fixture
     def test_pkgidlist2packages(self, load_cache):
         """Test making NEVRA from package id."""
-        pkgid_list = [1, 2]
+        pkgid_list = [pkg_id for pkg_id in self.cache.package_details][:10]
         nevras = utils.pkgidlist2packages(self.cache, pkgid_list)
         for nevra in nevras:
             assert self._is_nevra(nevra)

--- a/webapp/updates.py
+++ b/webapp/updates.py
@@ -268,7 +268,7 @@ class UpdatesAPI:
         return repo_ids
 
     def _build_nevra(self, update_pkg_id):
-        name_id, evr_id, arch_id, _, _ = self.db_cache.package_details[update_pkg_id]
+        name_id, evr_id, arch_id, _, _, _ = self.db_cache.package_details[update_pkg_id]
         name = self.db_cache.id2packagename[name_id]
         epoch, ver, rel = self.db_cache.id2evr[evr_id]
         arch = self.db_cache.id2arch[arch_id]


### PR DESCRIPTION
fixes

Traceback (most recent call last):\n  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/tornado/gen.py", line 191, in wrapper\n    result = func(*args, **kwargs)\n  File "/webapp/app.py", line 130, in handle_get\n    result = api_endpoint.process_list(api_version, {param_name : [param]})\n  File "/webapp/vulnerabilities.py", line 17, in process_list\n    updates = self.updates_api.process_list(2, data)\n  File "/webapp/updates.py", line 435, in process_list\n    available_repo_ids, repo_ids_key, response, module_ids)\n  File "/webapp/updates.py", line 337, in _process_updates\n    nevra = self._build_nevra(update_pkg_id)\n  File "/webapp/updates.py", line 271, in _build_nevra\n    name_id, evr_id, arch_id, _, _ = self.db_cache.package_details[update_pkg_id]\nValueError: too many values to unpack (expected 5)