### PR TITLE
fix getting srpm from source packages

### DIFF
--- a/reposcan/database/package_store.py
+++ b/reposcan/database/package_store.py
@@ -83,9 +83,8 @@ class PackageStore(ObjectStore):
         return name, epoch, ver, rel, arch
 
     def _get_source_package_id(self, pkg):
-        if pkg["srpm"] is None:
-            source_package_id = None
-        else:
+        source_package_id = None
+        if pkg["srpm"]:
             name, epoch, ver, rel, arch = PackageStore._get_source_package_nevra(pkg)
             name_id = self.package_name_map[name]
             evr_id = self.evr_map[(epoch, ver, rel)]
@@ -155,7 +154,8 @@ class PackageStore(ObjectStore):
     def _get_source_packages(packages):
         unique_source_packages = set()
         for pkg in packages:
-            unique_source_packages.add(PackageStore._get_source_package_nevra(pkg))
+            if pkg["srpm"]:
+                unique_source_packages.add(PackageStore._get_source_package_nevra(pkg))
         source_packages = []
         for name, epoch, ver, rel, arch in unique_source_packages:
             source_packages.append(dict(name=name, epoch=epoch, ver=ver, rel=rel, arch=arch,


### PR DESCRIPTION
fixing


> [ERROR] Internal server error <-9223363302935117324>'Traceback (most recent call last):\n  File "/reposcan/reposcan.py", line 661, in run_task\n    repository_controller.store()\n  File "/reposcan/repodata/repository_controller.py", line 264, in store\n    self.repo_store.store(repository)\n  File "/reposcan/database/repository_store.py", line 167, in store\n    self.package_store.store(repo_id, repository.list_packages())\n  File "/reposcan/database/package_store.py", line 169, in store\n    source_packages = self._get_source_packages(packages)\n  File "/reposcan/database/package_store.py", line 158, in _get_source_packages\n    unique_source_packages.add(PackageStore._get_source_package_nevra(pkg))\n  File "/reposcan/database/package_store.py", line 80, in _get_source_package_nevra\n    name, epoch, ver, rel, arch = rpm.parse_rpm_name(pkg["srpm"])\n  File "/reposcan/common/rpm.py", line 21, in parse_rpm_name\n    raise RPMParseException("Failed to parse srpm name!")\ncommon.rpm.RPMParseException: Failed to parse srpm name!'|


and

> [ERROR] Internal server error <-9223363253510724080>'Traceback (most recent call last):\n  File "/reposcan/reposcan.py", line 661, in run_task\n    repository_controller.store()\n  File "/reposcan/repodata/repository_controller.py", line 264, in store\n    self.repo_store.store(repository)\n  File "/reposcan/database/repository_store.py", line 167, in store\n    self.package_store.store(repo_id, repository.list_packages())\n  File "/reposcan/database/package_store.py", line 174, in store\n    package_ids = self._populate_packages(packages)\n  File "/reposcan/database/package_store.py", line 103, in _populate_packages\n    source_package_id = self._get_source_package_id(pkg)\n  File "/reposcan/database/package_store.py", line 89, in _get_source_package_id\n    name, epoch, ver, rel, arch = PackageStore._get_source_package_nevra(pkg)\n  File "/reposcan/database/package_store.py", line 80, in _get_source_package_nevra\n    name, epoch, ver, rel, arch = rpm.parse_rpm_name(pkg["srpm"])\n  File "/reposcan/common/rpm.py", line 21, in parse_rpm_name\n    raise RPMParseException("Failed to parse srpm name!")\ncommon.rpm.RPMParseException: Failed to parse srpm name!'|
