### PR TITLE
correct omitting of /opt in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,7 +180,7 @@ def runStages() {
             
             def status = 99
             status = sh(
-                script: "oc exec ${webapp_pod} -- coverage html --fail-under=${codecovThreshold} --omit '/opt/\\*' -d /tmp/htmlcov",
+                script: "oc exec ${webapp_pod} -- coverage html --fail-under=${codecovThreshold} --omit /opt/\\* -d /tmp/htmlcov",
                 returnStatus: true
             )
 


### PR DESCRIPTION
Now, when it is not executed using scl-enable.sh, --omit path should not be in quotes.