### PR TITLE
removed useless sql functions 'isdigit', 'isalpha', 'isalphanum'

### DIFF
--- a/database/vmaas_db_postgresql.sql
+++ b/database/vmaas_db_postgresql.sql
@@ -16,45 +16,6 @@ create type evr_t as (
         release evr_array_item[]
 );
 
-
-create or replace function isdigit(ch CHAR)
-    RETURNS BOOLEAN as $$
-    BEGIN
-        if ascii(ch) between ascii('0') and ascii('9')
-        then
-            return TRUE;
-        end if;
-        return FALSE;
-    END ;
-$$ language 'plpgsql';
-
-
-create or replace FUNCTION isalpha(ch CHAR)
-    RETURNS BOOLEAN as $$
-    BEGIN
-        if ascii(ch) between ascii('a') and ascii('z') or
-            ascii(ch) between ascii('A') and ascii('Z')
-        then
-            return TRUE;
-        end if;
-        return FALSE;
-    END;
-$$ language 'plpgsql';
-
-
-create or replace FUNCTION isalphanum(ch CHAR)
-RETURNS BOOLEAN as $$
-BEGIN
-    if ascii(ch) between ascii('a') and ascii('z') or
-        ascii(ch) between ascii('A') and ascii('Z') or
-        ascii(ch) between ascii('0') and ascii('9')
-    then
-        return TRUE;
-    end if;
-    return FALSE;
-END;
-$$ language 'plpgsql';
-
 create or replace FUNCTION empty(t TEXT)
 RETURNS BOOLEAN as $$
 BEGIN


### PR DESCRIPTION
functions were used in previously removed sql function 'rpmver_array'
now they are useless so they are removed