### PR TITLE
Jenkins - disable concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,9 @@ codecovThreshold = 89
 node {
     // Cancel any prior builds that are running for this job
     cancelPriorBuilds()
-
-    runStages()
+    lock("vmaas-qe-deploy") {
+        runStages()
+    }
 }
 
 


### PR DESCRIPTION
Use Lockable Resource Plugin to lock openshift vmaas-qe project resource while tests are running.