### PR TITLE
/repos API + modified_since wrong and inconsistent results

### DIFF
--- a/webapp/repos.py
+++ b/webapp/repos.py
@@ -87,6 +87,7 @@ class RepoAPI:
                 repo_details[label] = self.cache.repo_detail[repo_id]
         filters.append((filter_item_if_exists, [repo_details]))
 
+        actual_page_size = 0
         repo_page_to_process, pagination_response = paginate(repos, page, page_size, filters=filters)
         for label in repo_page_to_process:
             for repo_id in self.cache.repolabel2ids.get(label, []):
@@ -101,10 +102,13 @@ class RepoAPI:
                     "product": repo_detail[REPO_PRODUCT],
                     "revision": repo_detail[REPO_REVISION]
                 })
+            actual_page_size += len(repolist[label])
 
         response = {
             'repository_list': repolist,
         }
+
+        pagination_response['page_size'] = actual_page_size
         response.update(pagination_response)
         if modified_since:
             response["modified_since"] = modified_since

--- a/webapp/test/test_repos.py
+++ b/webapp/test/test_repos.py
@@ -1,5 +1,6 @@
 """Unit test for CveAPI module."""
-from test import schemas
+
+from test import schemas, tools
 from test.conftest import TestBase
 
 import pytest
@@ -9,6 +10,10 @@ from repos import RepoAPI
 REPO_JSON_EMPTY = {}
 REPO_JSON_BAD = {"page_size": 9}
 REPO_JSON = {"repository_list": ["rhel-7-server-rpms"]}
+REPO_JSON_MODIFIED_SINCE = {
+    "repository_list": ["rhel-7-server-rpms"],
+    "modified_since": "2099-01-01T00:00:00+00:00"
+}
 REPO_JSON_EMPTY_LIST = {"repository_list": [""]}
 REPO_JSON_NON_EXIST = {"repository_list": ["non-existent-repo"]}
 
@@ -55,7 +60,7 @@ class TestRepoAPI(TestBase):
         assert response == EMPTY_RESPONSE
 
     def test_non_existing_repo(self):
-        """Test repos API repsonse for non-existent repo."""
+        """Test repos API response for non-existent repo."""
         response = self.repo.process_list(api_version="v1", data=REPO_JSON_NON_EXIST)
         assert response == EMPTY_RESPONSE
 
@@ -63,3 +68,24 @@ class TestRepoAPI(TestBase):
         """Test schema of valid repos API response."""
         response = self.repo.process_list(api_version="v1", data=REPO_JSON)
         assert schemas.repos_schema.validate(response)
+
+    def test_modified_since(self):
+        """Test repos API with 'modified_since' property."""
+        response = self.repo.process_list(api_version=1, data=REPO_JSON_MODIFIED_SINCE)
+        assert tools.match(EMPTY_RESPONSE, response) is True
+
+    def test_page_size(self):
+        """Test repos API page size"""
+        response = self.repo.process_list(api_version="v1", data=REPO_JSON)
+        page_size = 0
+        for label in response['repository_list']:
+            page_size += len(response['repository_list'][label])
+        assert response['page_size'] == page_size
+
+    def test_page_size_mod_since(self):
+        """Test repos API page size with 'modified_since' property"""
+        response = self.repo.process_list(api_version="v1", data=REPO_JSON_MODIFIED_SINCE)
+        page_size = 0
+        for label in response['repository_list']:
+            page_size += len(response['repository_list'][label])
+        assert response['page_size'] == page_size


### PR DESCRIPTION
`curl -X POST -d '{"repository_list": ["rhel-7-server-rpms"]}' localhost:8080/api/v1/repos/ | python -m json.tool`

```{
    "page": 1,
    "page_size": 2,
    "pages": 1,
    "repository_list": {
        "rhel-7-server-rpms": [
            {
                "basearch": "x86_64",
                "label": "rhel-7-server-rpms",
                "name": "Red Hat Enterprise Linux 7 Server (RPMs)",
                "product": "Red Hat Enterprise Linux Server",
                "releasever": "7.4",
                "revision": "None",
                "url": "https://cdn.redhat.com/content/dist/rhel/server/7/7.4/x86_64/os/"
            },
            {
                "basearch": "x86_64",
                "label": "rhel-7-server-rpms",
                "name": "Red Hat Enterprise Linux 7 Server (RPMs)",
                "product": "Red Hat Enterprise Linux Server",
                "releasever": "7Server",
                "revision": "2018-04-10T09:02:26+00:00",
                "url": "http://vmaas-data-vmaas-qe.5a9f.insights-dev.openshiftapps.com/repodata-for-vmaas/rhel/server/7/7Server/x86_64/os/"
            }
        ]
    }
}
```
The problem was that API returns repository list which contain list of repositories by label key, so modified_since parameter doesn't work and does not filter any repo, also problem with page size has the same roots