### PR TITLE
Accept repomd entries without size

### DIFF
--- a/reposcan/repodata/repomd.py
+++ b/reposcan/repodata/repomd.py
@@ -38,9 +38,10 @@ class RepoMD:
                 "location": location,
                 "checksum_type": checksum_type,
                 "checksum": checksum,
-                "size": int(size.text)
             }
 
+            if size:
+                self.data[data_type]["size"] = int(size.text)
             if open_size:
                 self.data[data_type]["open-size"] = int(open_size.text)
 

--- a/reposcan/repodata/repository_controller.py
+++ b/reposcan/repodata/repository_controller.py
@@ -246,7 +246,7 @@ class RepositoryController:
             try:
                 mdata = repomd.get_metadata(data_type)
                 # open-size is not present for uncompressed files
-                return int(mdata['size']) + int(mdata.get('open-size', '0'))
+                return int(mdata.get('size', 0)) + int(mdata.get('open-size', '0'))
             except RepoMDTypeNotFound:
                 return 0
 

--- a/reposcan/repodata/test/test_repomd.py
+++ b/reposcan/repodata/test/test_repomd.py
@@ -21,8 +21,8 @@ class TestRepoMD(unittest.TestCase):
         self.assertEqual(self.repomd.get_revision(), self.repomd_primary_only.get_revision())
 
     def _test_repomd(self, data):
-        intended_fields = ["location", "checksum_type", "checksum", "size"]
-        optional_fields = ["open-size"]
+        intended_fields = ["location", "checksum_type", "checksum"]
+        optional_fields = ["open-size", "size"]
         actual_fields = data.keys()
         for field in intended_fields:
             self.assertTrue(field in actual_fields, field)


### PR DESCRIPTION
This fixes bug introduced by #578, which resulted in sync error when `repomd.xml` entries did not have size.