### PR TITLE
Add error formatter and edit webapp spec

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -3,13 +3,13 @@
 Main web API module
 """
 
+from json import loads
 import os
 import signal
 import sre_constants
 import time
 import asyncio
 import yaml
-from json import loads
 
 from jsonschema.exceptions import ValidationError
 from prometheus_client import generate_latest
@@ -380,6 +380,7 @@ def create_app():
 
     @web.middleware
     async def error_formater(request, handler, **kwargs):
+        #pylint: disable=broad-except
         def build_error(detail, status):
             errors = {"detail": detail, "status": status}
             return {"errors": [errors]}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -9,6 +9,7 @@ import sre_constants
 import time
 import asyncio
 import yaml
+from json import loads
 
 from jsonschema.exceptions import ValidationError
 from prometheus_client import generate_latest
@@ -377,10 +378,30 @@ def create_app():
 
         return res
 
+    @web.middleware
+    async def error_formater(request, handler, **kwargs):
+        def build_error(detail, status):
+            errors = {"detail": detail, "status": status}
+            return {"errors": [errors]}
+
+        res = await handler(request, **kwargs)
+
+        try:
+            if res.status >= 400:
+                original_error = loads(res.body)
+                better_error = build_error(original_error["detail"], original_error["status"])
+                return web.json_response(better_error, status=res.status)
+            return res
+        except Exception as _:
+            LOGGER.exception(_)
+            return web.json_response(build_error("Internal server error", 500), status=500)
+
+
     app = connexion.AioHttpApp(__name__, options={
         'swagger_ui': True,
         'openapi_spec_path': '/v1/apispec',
-        'middlewares': [timing_middleware]
+        'middlewares': [error_formater,
+                        timing_middleware]
     })
 
     def metrics(request, **kwargs): #pylint: disable=unused-argument

--- a/webapp/test/test_app.py
+++ b/webapp/test/test_app.py
@@ -76,7 +76,7 @@ class TestWebappPosts(BaseCase):
         body = """{"package_list": []}"""
         resp = await self.fetch('/api/v1/updates', method='POST', data=body)
         assert HTTPStatus.BAD_REQUEST == resp.status
-        assert resp.body[:32] == '"package_list : [] is too short"'
+        assert resp.body[:40] == '{"errors": [{"detail": "[] is too short"'
 
     async def test_updates_v2_post_1(self):
         """Test updates post endpoint."""

--- a/webapp/webapp.spec.yaml
+++ b/webapp/webapp.spec.yaml
@@ -364,6 +364,7 @@ components:
           items:
             type: string
             example: kernel-2.6.32-696.20.1.el6.x86_64
+          minItems: 1
         repository_list:
           type: array
           items:
@@ -380,6 +381,9 @@ components:
               module_stream:
                 type: string
                 example: '1'
+            required:
+              - module_name
+              - module_stream
         releasever:
           type: string
           example: 6Server
@@ -502,7 +506,11 @@ components:
           items:
             type: string
             example: CVE-2017-57.*
+          minItems: 1
         modified_since:
+          type: string
+          example: '2018-04-05T01:23:45+02:00'
+        published_since:
           type: string
           example: '2018-04-05T01:23:45+02:00'
         rh_only:
@@ -585,6 +593,7 @@ components:
           items:
             type: string
             example: rhel-6-server-rpms
+          minItems: 1
         modified_since:
           type: string
           example: '2018-04-05T01:23:45+02:00'
@@ -633,6 +642,7 @@ components:
           items:
             type: string
             example: 'RHSA-2018:05.*'
+          minItems: 1
         modified_since:
           type: string
           example: '2018-04-05T01:23:45+02:00'
@@ -712,6 +722,7 @@ components:
           items:
             type: string
             example: kernel-2.6.32-696.20.1.el6.x86_64
+          minItems: 1
       required:
         - package_list
     PackagesResponse:


### PR DESCRIPTION
Now the errors should look exactly like the ones from vulnerability engine.
The webapp spec was edited to match the jsons exactly inside ```.py``` files, so that the validation error gets done only by connexion, so that the new middleware ```error_formater``` would work properly. 