### PR TITLE
pin insights-pipeline-lib version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@
  * Requires: https://github.com/RedHatInsights/insights-pipeline-lib
  */
 
-@Library("github.com/RedHatInsights/insights-pipeline-lib") _
+@Library("github.com/RedHatInsights/insights-pipeline-lib@v1.3") _
 
 // Code coverage failure threshold
 codecovThreshold = 89


### PR DESCRIPTION
There is a new feature in insights-pipeline-lib that changes functionality of `openshift.withNode`, we can pin insights-pipeline-lib to v1.3 for now and do the necessary changes later