### PR TITLE
Allow downloading repolist from git

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,6 +25,7 @@ schema = ">=0.7.0"
 tornado = ">=6.0.3"
 pyyaml = ">=5.1.2"
 requests = ">=2.22.0"
+gitpython = ">=3.0.3"
 
 [requires]
 python_version = "3.6"

--- a/conf/reposcan.env
+++ b/conf/reposcan.env
@@ -13,7 +13,7 @@ WEBSOCKET_HOST=vmaas_websocket
 KEEP_COPIES=3
 AUTHORIZED_API_ORG=RedHatInsights
 REPOLIST_GIT=https://github.com/RedHatInsights/vmaas-assets.git
-REPOLIST_GIT_TOKEN=ENTER_TOKEN_HERE
+REPOLIST_GIT_TOKEN=
 REPOLIST_PATH=repolist.json
 # dummy values to make git clone work in openshift env (https://github.com/openshift/origin/issues/8374)
 GIT_COMMITTER_NAME=vmaas

--- a/conf/reposcan.env
+++ b/conf/reposcan.env
@@ -15,3 +15,6 @@ AUTHORIZED_API_ORG=RedHatInsights
 REPOLIST_GIT=https://github.com/RedHatInsights/vmaas-assets.git
 REPOLIST_GIT_TOKEN=ENTER_TOKEN_HERE
 REPOLIST_PATH=repolist.json
+# dummy values to make git clone work in openshift env (https://github.com/openshift/origin/issues/8374)
+GIT_COMMITTER_NAME=vmaas
+GIT_COMMITTER_EMAIL=vmaas@localhost

--- a/conf/reposcan.env
+++ b/conf/reposcan.env
@@ -12,3 +12,6 @@ PKGTREE_KEEP_COPIES=2
 WEBSOCKET_HOST=vmaas_websocket
 KEEP_COPIES=3
 AUTHORIZED_API_ORG=RedHatInsights
+REPOLIST_GIT=https://github.com/RedHatInsights/vmaas-assets.git
+REPOLIST_GIT_TOKEN=ENTER_TOKEN_HERE
+REPOLIST_PATH=repolist.json

--- a/conf/reposcan.env
+++ b/conf/reposcan.env
@@ -18,3 +18,6 @@ REPOLIST_PATH=repolist.json
 # dummy values to make git clone work in openshift env (https://github.com/openshift/origin/issues/8374)
 GIT_COMMITTER_NAME=vmaas
 GIT_COMMITTER_EMAIL=vmaas@localhost
+DEFAULT_CA_CERT=
+DEFAULT_CERT=
+DEFAULT_KEY=

--- a/openshift/secrets.yml
+++ b/openshift/secrets.yml
@@ -5,3 +5,11 @@ kind: Secret
 metadata:
   name: github-vulnerability-bot
 type: Opaque
+
+apiVersion: v1
+data:
+  GIT_TOKEN: ""
+kind: Secret
+metadata:
+  name: github-vmaas-bot
+type: Opaque

--- a/openshift/secrets.yml
+++ b/openshift/secrets.yml
@@ -13,3 +13,13 @@ kind: Secret
 metadata:
   name: github-vmaas-bot
 type: Opaque
+
+apiVersion: v1
+data:
+  DEFAULT_CA_CERT: ''
+  DEFAULT_CERT: ''
+  DEFAULT_KEY: ''
+kind: Secret
+metadata:
+  name: cdn-certificate
+type: Opaque

--- a/openshift/vmaas-reposcan.yml
+++ b/openshift/vmaas-reposcan.yml
@@ -30,7 +30,8 @@ objects:
     REPOSCAN_SYNC_INTERVAL_MINUTES: '360'
     REPOLIST_GIT: 'https://github.com/RedHatInsights/vmaas-assets.git'
     REPOLIST_PATH: 'repolist.json'
-    REPOLIST_GIT_TOKEN: ''
+    GIT_COMMITTER_NAME: 'vmaas'
+    GIT_COMMITTER_EMAIL: 'vmaas@localhost'
 
     RETRY_COUNT: '3'
     THREADS: '8'
@@ -271,8 +272,18 @@ objects:
                 name: vmaas-reposcan-conf-reposcan-env-${RELEASE}
           - name: REPOLIST_GIT_TOKEN
             valueFrom:
+              secretKeyRef:
+                key: GIT_TOKEN
+                name: github-vmaas-bot
+          - name: GIT_COMMITTER_NAME
+            valueFrom:
               configMapKeyRef:
-                key: REPOLIST_GIT_TOKEN
+                key: GIT_COMMITTER_NAME
+                name: vmaas-reposcan-conf-reposcan-env-${RELEASE}
+          - name: GIT_COMMITTER_EMAIL
+            valueFrom:
+              configMapKeyRef:
+                key: GIT_COMMITTER_EMAIL
                 name: vmaas-reposcan-conf-reposcan-env-${RELEASE}
 
           image: ' '

--- a/openshift/vmaas-reposcan.yml
+++ b/openshift/vmaas-reposcan.yml
@@ -285,6 +285,21 @@ objects:
               configMapKeyRef:
                 key: GIT_COMMITTER_EMAIL
                 name: vmaas-reposcan-conf-reposcan-env-${RELEASE}
+          - name: DEFAULT_CA_CERT
+            valueFrom:
+              secretKeyRef:
+                key: DEFAULT_CA_CERT
+                name: cdn-certificate
+          - name: DEFAULT_CERT
+            valueFrom:
+              secretKeyRef:
+                key: DEFAULT_CERT
+                name: cdn-certificate
+          - name: DEFAULT_KEY
+            valueFrom:
+              secretKeyRef:
+                key: DEFAULT_KEY
+                name: cdn-certificate
 
           image: ' '
           name: vmaas-reposcan

--- a/openshift/vmaas-reposcan.yml
+++ b/openshift/vmaas-reposcan.yml
@@ -28,6 +28,10 @@ objects:
     PKGTREE_INDENT: '0'
     PKGTREE_KEEP_COPIES: '2'
     REPOSCAN_SYNC_INTERVAL_MINUTES: '360'
+    REPOLIST_GIT: 'https://github.com/RedHatInsights/vmaas-assets.git'
+    REPOLIST_PATH: 'repolist.json'
+    REPOLIST_GIT_TOKEN: ''
+
     RETRY_COUNT: '3'
     THREADS: '8'
     YEAR_SINCE: '2002'
@@ -255,6 +259,22 @@ objects:
               configMapKeyRef:
                 key: KEEP_COPIES
                 name: vmaas-reposcan-conf-reposcan-env-${RELEASE}
+          - name: REPOLIST_GIT
+            valueFrom:
+              configMapKeyRef:
+                key: REPOLIST_GIT
+                name: vmaas-reposcan-conf-reposcan-env-${RELEASE}
+          - name: REPOLIST_PATH
+            valueFrom:
+              configMapKeyRef:
+                key: REPOLIST_PATH
+                name: vmaas-reposcan-conf-reposcan-env-${RELEASE}
+          - name: REPOLIST_GIT_TOKEN
+            valueFrom:
+              configMapKeyRef:
+                key: REPOLIST_GIT_TOKEN
+                name: vmaas-reposcan-conf-reposcan-env-${RELEASE}
+
           image: ' '
           name: vmaas-reposcan
           ports:

--- a/reposcan/Dockerfile
+++ b/reposcan/Dockerfile
@@ -5,7 +5,7 @@ ADD /scripts/generate_rpm_list.sh /generate_rpm_list.sh
 RUN /generate_rpm_list.sh | grep -v -E "^(redhat|centos|fedora)-release" > /tmp/base_rpm_list.txt
 
 RUN yum -y install centos-release-scl && \
-    yum -y install rh-python36 which postgresql postgresql-libs rsync && \
+    yum -y install rh-python36 which postgresql postgresql-libs rsync git && \
     rm -rf /var/cache/yum/*
 
 ENV PATH=/opt/rh/rh-python36/root/usr/bin:$PATH

--- a/reposcan/Dockerfile.rhel7
+++ b/reposcan/Dockerfile.rhel7
@@ -5,7 +5,7 @@ ADD /scripts/generate_rpm_list.sh /generate_rpm_list.sh
 RUN /generate_rpm_list.sh | grep -v -E "^(redhat|centos|fedora)-release" > /tmp/base_rpm_list.txt
 
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
-    yum -y install rh-python36 which postgresql postgresql-libs rsync && \
+    yum -y install rh-python36 which postgresql postgresql-libs rsync git && \
     rm -rf /var/cache/yum/*
 
 ENV PATH=/opt/rh/rh-python36/root/usr/bin:$PATH

--- a/reposcan/Pipfile
+++ b/reposcan/Pipfile
@@ -21,6 +21,7 @@ prometheus-client = ">=0.7.1"
 pyyaml = ">=5.1.2"
 requests = ">=2.22.0"
 tornado = ">=6.0.3"
+gitpython = ">=3.0.3"
 
 [requires]
 python_version = "3.6"

--- a/reposcan/Pipfile.lock
+++ b/reposcan/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "849f94b08d17884bf7a3871675d4f5fcebf974ab5d88260e5fa439b491a660aa"
+            "sha256": "ee9e79cb69ddc61d09ca9da15a2a5b0c16318ba8344c217268fbd0abb6b28af9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -63,6 +63,21 @@
             "index": "pypi",
             "version": "==1.1.1"
         },
+        "gitdb2": {
+            "hashes": [
+                "sha256:1b6df1433567a51a4a9c1a5a0de977aa351a405cc56d7d35f3388bad1f630350",
+                "sha256:96bbb507d765a7f51eb802554a9cfe194a174582f772e0d89f4e87288c288b7b"
+            ],
+            "version": "==2.0.6"
+        },
+        "gitpython": {
+            "hashes": [
+                "sha256:9c2398ffc3dcb3c40b27324b316f08a4f93ad646d5a6328cafbb871aa79f5e42",
+                "sha256:c155c6a2653593ccb300462f6ef533583a913e17857cfef8fc617c246b6dc245"
+            ],
+            "index": "pypi",
+            "version": "==3.0.5"
+        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
@@ -85,10 +100,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
-                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
+                "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f",
+                "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"
             ],
-            "version": "==2.10.1"
+            "version": "==2.10.3"
         },
         "jsonschema": {
             "hashes": [
@@ -147,45 +162,49 @@
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:080c72714784989474f97be9ab0ddf7b2ad2984527e77f2909fcd04d4df53809",
-                "sha256:110457be80b63ff4915febb06faa7be002b93a76e5ba19bf3f27636a2ef58598",
-                "sha256:171352a03b22fc099f15103959b52ee77d9a27e028895d7e5fde127aa8e3bac5",
-                "sha256:19d013e7b0817087517a4b3cab39c084d78898369e5c46258aab7be4f233d6a1",
-                "sha256:249b6b21ae4eb0f7b8423b330aa80fab5f821b9ffc3f7561a5e2fd6bb142cf5d",
-                "sha256:2ac0731d2d84b05c7bb39e85b7e123c3a0acd4cda631d8d542802c88deb9e87e",
-                "sha256:2b6d561193f0dc3f50acfb22dd52ea8c8dfbc64bcafe3938b5f209cc17cb6f00",
-                "sha256:2bd23e242e954214944481124755cbefe7c2cf563b1a54cd8d196d502f2578bf",
-                "sha256:3e1239242ca60b3725e65ab2f13765fc199b03af9eaf1b5572f0e97bdcee5b43",
-                "sha256:3eb70bb697abbe86b1d2b1316370c02ba320bfd1e9e35cf3b9566a855ea8e4e5",
-                "sha256:51a2fc7e94b98bd1bb5d4570936f24fc2b0541b63eccadf8fdea266db8ad2f70",
-                "sha256:52f1bdafdc764b7447e393ed39bb263eccb12bfda25a4ac06d82e3a9056251f6",
-                "sha256:5b3581319a3951f1e866f4f6c5e42023db0fae0284273b82e97dfd32c51985cd",
-                "sha256:63c1b66e3b2a3a336288e4bcec499e0dc310cd1dceaed1c46fa7419764c68877",
-                "sha256:8123a99f24ecee469e5c1339427bcdb2a33920a18bb5c0d58b7c13f3b0298ba3",
-                "sha256:85e699fcabe7f817c0f0a412d4e7c6627e00c412b418da7666ff353f38e30f67",
-                "sha256:8dbff4557bbef963697583366400822387cccf794ccb001f1f2307ed21854c68",
-                "sha256:908d21d08d6b81f1b7e056bbf40b2f77f8c499ab29e64ec5113052819ef1c89b",
-                "sha256:af39d0237b17d0a5a5f638e9dffb34013ce2b1d41441fd30283e42b22d16858a",
-                "sha256:af51bb9f055a3f4af0187149a8f60c9d516cf7d5565b3dac53358796a8fb2a5b",
-                "sha256:b2ecac57eb49e461e86c092761e6b8e1fd9654dbaaddf71a076dcc869f7014e2",
-                "sha256:cd37cc170678a4609becb26b53a2bc1edea65177be70c48dd7b39a1149cabd6e",
-                "sha256:d17e3054b17e1a6cb8c1140f76310f6ede811e75b7a9d461922d2c72973f583e",
-                "sha256:d305313c5a9695f40c46294d4315ed3a07c7d2b55e48a9010dad7db7a66c8b7f",
-                "sha256:dd0ef0eb1f7dd18a3f4187226e226a7284bda6af5671937a221766e6ef1ee88f",
-                "sha256:e1adff53b56db9905db48a972fb89370ad5736e0450b96f91bcf99cadd96cfd7",
-                "sha256:f0d43828003c82dbc9269de87aa449e9896077a71954fbbb10a614c017e65737",
-                "sha256:f78e8b487de4d92640105c1389e5b90be3496b1d75c90a666edd8737cc2dbab7"
+                "sha256:040234f8a4a8dfd692662a8308d78f63f31a97e1c42d2480e5e6810c48966a29",
+                "sha256:086f7e89ec85a6704db51f68f0dcae432eff9300809723a6e8782c41c2f48e03",
+                "sha256:18ca813fdb17bc1db73fe61b196b05dd1ca2165b884dd5ec5568877cabf9b039",
+                "sha256:19dc39616850342a2a6db70559af55b22955f86667b5f652f40c0e99253d9881",
+                "sha256:2166e770cb98f02ed5ee2b0b569d40db26788e0bf2ec3ae1a0d864ea6f1d8309",
+                "sha256:3a2522b1d9178575acee4adf8fd9f979f9c0449b00b4164bb63c3475ea6528ed",
+                "sha256:3aa773580f85a28ffdf6f862e59cb5a3cc7ef6885121f2de3fca8d6ada4dbf3b",
+                "sha256:3b5deaa3ee7180585a296af33e14c9b18c218d148e735c7accf78130765a47e3",
+                "sha256:407af6d7e46593415f216c7f56ba087a9a42bd6dc2ecb86028760aa45b802bd7",
+                "sha256:4c3c09fb674401f630626310bcaf6cd6285daf0d5e4c26d6e55ca26a2734e39b",
+                "sha256:4c6717962247445b4f9e21c962ea61d2e884fc17df5ddf5e35863b016f8a1f03",
+                "sha256:50446fae5681fc99f87e505d4e77c9407e683ab60c555ec302f9ac9bffa61103",
+                "sha256:5057669b6a66aa9ca118a2a860159f0ee3acf837eda937bdd2a64f3431361a2d",
+                "sha256:5dd90c5438b4f935c9d01fcbad3620253da89d19c1f5fca9158646407ed7df35",
+                "sha256:659c815b5b8e2a55193ede2795c1e2349b8011497310bb936da7d4745652823b",
+                "sha256:69b13fdf12878b10dc6003acc8d0abf3ad93e79813fd5f3812497c1c9fb9be49",
+                "sha256:7a1cb80e35e1ccea3e11a48afe65d38744a0e0bde88795cc56a4d05b6e4f9d70",
+                "sha256:7e6e3c52e6732c219c07bd97fff6c088f8df4dae3b79752ee3a817e6f32e177e",
+                "sha256:7f42a8490c4fe854325504ce7a6e4796b207960dabb2cbafe3c3959cb00d1d7e",
+                "sha256:84156313f258eafff716b2961644a4483a9be44a5d43551d554844d15d4d224e",
+                "sha256:8578d6b8192e4c805e85f187bc530d0f52ba86c39172e61cd51f68fddd648103",
+                "sha256:890167d5091279a27e2505ff0e1fb273f8c48c41d35c5b92adbf4af80e6b2ed6",
+                "sha256:98e10634792ac0e9e7a92a76b4991b44c2325d3e7798270a808407355e7bb0a1",
+                "sha256:9aadff9032e967865f9778485571e93908d27dab21d0fdfdec0ca779bb6f8ad9",
+                "sha256:9f24f383a298a0c0f9b3113b982e21751a8ecde6615494a3f1470eb4a9d70e9e",
+                "sha256:a73021b44813b5c84eda4a3af5826dd72356a900bac9bd9dd1f0f81ee1c22c2f",
+                "sha256:afd96845e12638d2c44d213d4810a08f4dc4a563f9a98204b7428e567014b1cd",
+                "sha256:b73ddf033d8cd4cc9dfed6324b1ad2a89ba52c410ef6877998422fcb9c23e3a8",
+                "sha256:b8f490f5fad1767a1331df1259763b3bad7d7af12a75b950c2843ba319b2415f",
+                "sha256:dbc5cd56fff1a6152ca59445178652756f4e509f672e49ccdf3d79c1043113a4",
+                "sha256:eac8a3499754790187bb00574ab980df13e754777d346f85e0ff6df929bcd964",
+                "sha256:eaed1c65f461a959284649e37b5051224f4db6ebdc84e40b5e65f2986f101a08"
             ],
             "index": "pypi",
-            "version": "==2.8.3"
+            "version": "==2.8.4"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
-                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
             "index": "pypi",
-            "version": "==2.8.0"
+            "version": "==2.8.1"
         },
         "pyyaml": {
             "hashes": [
@@ -216,18 +235,25 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
+        },
+        "smmap2": {
+            "hashes": [
+                "sha256:0555a7bf4df71d1ef4218e4807bbf9b201f910174e6e08af2e138d4e517b4dde",
+                "sha256:29a9ffa0497e7f2be94ca0ed1ca1aa3cd4cf25a1f6b4f5f87f74b46ed91d609a"
+            ],
+            "version": "==2.0.5"
         },
         "swagger-ui-bundle": {
             "hashes": [
-                "sha256:01ae8fdb1fa4e034933e0874afdda0d433dcb94476fccb231b66fd5f49dac96c",
-                "sha256:802f160dd6fe1d6b8fa92c6a40f593ef52f87ad0f507b1170ad2067f03de4c01",
-                "sha256:e88bd0d8334d685440a85210ff1e1083a0caabd4c36fa061843067ff4c2ac680"
+                "sha256:49d2e12d60a6499e9d37ea37953b5d700f4e114edc7520fe918bae5eb693a20e",
+                "sha256:c5373b683487b1b914dccd23bcd9a3016afa2c2d1cda10f8713c0a9af0f91dd3",
+                "sha256:f776811855092c086dbb08216c8810a84accef8c76c796a135caa13645c5cc68"
             ],
-            "version": "==0.0.5"
+            "version": "==0.0.6"
         },
         "tornado": {
             "hashes": [
@@ -244,26 +270,26 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
-                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
+                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
             ],
-            "version": "==1.25.3"
+            "version": "==1.25.7"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:00d32beac38fcd48d329566f80d39f10ec2ed994efbecfb8dd4b320062d05902",
-                "sha256:0a24d43be6a7dce81bae05292356176d6c46d63e42a0dd3f9504b210a9cfaa43"
+                "sha256:7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7",
+                "sha256:e5f4a1f98b52b18a93da705a7458e55afb26f32bff83ff5d19189f92462d65c4"
             ],
-            "version": "==0.15.6"
+            "version": "==0.16.0"
         }
     },
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
-                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
+                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
+                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
             ],
-            "version": "==2.2.5"
+            "version": "==2.3.3"
         },
         "atomicwrites": {
             "hashes": [
@@ -274,10 +300,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
-                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
-            "version": "==19.1.0"
+            "version": "==19.3.0"
         },
         "click": {
             "hashes": [
@@ -334,11 +360,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:652234b6ab8f2506ae58e528b6fbcc668831d3cc758e1bc01ef438d328b68cdb",
-                "sha256:6f264986fb88042bc1f0535fa9a557e6a376cfe5679dc77caac7fe8b5d43d05f"
+                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
+                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==0.22"
+            "version": "==0.23"
         },
         "isort": {
             "hashes": [
@@ -356,33 +382,36 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
-                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
+                "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f",
+                "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"
             ],
-            "version": "==2.10.1"
+            "version": "==2.10.3"
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:02b260c8deb80db09325b99edf62ae344ce9bc64d68b7a634410b8e9a568edbf",
-                "sha256:18f9c401083a4ba6e162355873f906315332ea7035803d0fd8166051e3d402e3",
-                "sha256:1f2c6209a8917c525c1e2b55a716135ca4658a3042b5122d4e3413a4030c26ce",
-                "sha256:2f06d97f0ca0f414f6b707c974aaf8829c2292c1c497642f63824119d770226f",
-                "sha256:616c94f8176808f4018b39f9638080ed86f96b55370b5a9463b2ee5c926f6c5f",
-                "sha256:63b91e30ef47ef68a30f0c3c278fbfe9822319c15f34b7538a829515b84ca2a0",
-                "sha256:77b454f03860b844f758c5d5c6e5f18d27de899a3db367f4af06bec2e6013a8e",
-                "sha256:83fe27ba321e4cfac466178606147d3c0aa18e8087507caec78ed5a966a64905",
-                "sha256:84742532d39f72df959d237912344d8a1764c2d03fe58beba96a87bfa11a76d8",
-                "sha256:874ebf3caaf55a020aeb08acead813baf5a305927a71ce88c9377970fe7ad3c2",
-                "sha256:9f5caf2c7436d44f3cec97c2fa7791f8a675170badbfa86e1992ca1b84c37009",
-                "sha256:a0c8758d01fcdfe7ae8e4b4017b13552efa7f1197dd7358dc9da0576f9d0328a",
-                "sha256:a4def978d9d28cda2d960c279318d46b327632686d82b4917516c36d4c274512",
-                "sha256:ad4f4be843dace866af5fc142509e9b9817ca0c59342fdb176ab6ad552c927f5",
-                "sha256:ae33dd198f772f714420c5ab698ff05ff900150486c648d29951e9c70694338e",
-                "sha256:b4a2b782b8a8c5522ad35c93e04d60e2ba7f7dcb9271ec8e8c3e08239be6c7b4",
-                "sha256:c462eb33f6abca3b34cdedbe84d761f31a60b814e173b98ede3c81bb48967c4f",
-                "sha256:fd135b8d35dfdcdb984828c84d695937e58cc5f49e1c854eb311c4d6aa03f4f1"
+                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
+                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
+                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
+                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
+                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
+                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
+                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
+                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
+                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
+                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
+                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
+                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
+                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
+                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
+                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
+                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
+                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
+                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
+                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
+                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
+                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
             ],
-            "version": "==1.4.2"
+            "version": "==1.4.3"
         },
         "markupsafe": {
             "hashes": [
@@ -433,10 +462,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9",
-                "sha256:c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe"
+                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
+                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
             ],
-            "version": "==19.1"
+            "version": "==19.2"
         },
         "pg8000": {
             "hashes": [
@@ -468,34 +497,34 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
-                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
+                "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd",
+                "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"
             ],
             "index": "pypi",
-            "version": "==2.3.1"
+            "version": "==2.4.4"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
-                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
+                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.5"
         },
         "pytest": {
             "hashes": [
-                "sha256:95d13143cc14174ca1a01ec68e84d76ba5d9d493ac02716fd9706c949a505210",
-                "sha256:b78fe2881323bd44fd9bd76e5317173d4316577e7b1cddebae9136a4495ec865"
+                "sha256:8e256fe71eb74e14a4d20a5987bb5e1488f0511ee800680aaedc62b9358714e8",
+                "sha256:ff0090819f669aaa0284d0f4aad1a6d9d67a6efdc6dd4eb4ac56b704f890a0d6"
             ],
             "index": "pypi",
-            "version": "==5.1.2"
+            "version": "==5.2.4"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6",
-                "sha256:e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"
+                "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b",
+                "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"
             ],
             "index": "pypi",
-            "version": "==2.7.1"
+            "version": "==2.8.1"
         },
         "pytest-flask": {
             "hashes": [
@@ -514,10 +543,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "testing-postgresql": {
             "hashes": [
@@ -535,23 +564,28 @@
         },
         "typed-ast": {
             "hashes": [
+                "sha256:1170afa46a3799e18b4c977777ce137bb53c7485379d9706af8a59f2ea1aa161",
                 "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e",
                 "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e",
                 "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0",
                 "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c",
+                "sha256:48e5b1e71f25cfdef98b013263a88d7145879fbb2d5185f2a0c79fa7ebbeae47",
                 "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631",
                 "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4",
                 "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34",
                 "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b",
+                "sha256:7954560051331d003b4e2b3eb822d9dd2e376fa4f6d98fee32f452f52dd6ebb2",
+                "sha256:838997f4310012cf2e1ad3803bce2f3402e9ffb71ded61b5ee22617b3a7f6b6e",
                 "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a",
                 "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233",
                 "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1",
                 "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36",
                 "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d",
                 "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
+                "sha256:fdc1c9bbf79510b76408840e009ed65958feba92a88833cdceecff93ae8fff66",
                 "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
             ],
-            "markers": "implementation_name == 'cpython'",
+            "markers": "implementation_name == 'cpython' and python_version < '3.8'",
             "version": "==1.4.0"
         },
         "wcwidth": {
@@ -563,10 +597,10 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:00d32beac38fcd48d329566f80d39f10ec2ed994efbecfb8dd4b320062d05902",
-                "sha256:0a24d43be6a7dce81bae05292356176d6c46d63e42a0dd3f9504b210a9cfaa43"
+                "sha256:7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7",
+                "sha256:e5f4a1f98b52b18a93da705a7458e55afb26f32bff83ff5d19189f92462d65c4"
             ],
-            "version": "==0.15.6"
+            "version": "==0.16.0"
         },
         "wrapt": {
             "hashes": [

--- a/reposcan/repodata/repository_controller.py
+++ b/reposcan/repodata/repository_controller.py
@@ -90,9 +90,11 @@ class RepositoryController:
             local_path = os.path.join(repo.tmp_directory, os.path.basename(md_path))
             if local_path in failed_items:
                 failed = True
-                self.logger.warning("Download failed: LABEL: %s URL: %s (HTTP CODE %d)",
-                                    repo.content_set, urljoin(repo.repo_url, md_path),
-                                    failed_items[local_path])
+                # Download errors with no HTTP code are logged in downloader, deduplicate error msgs
+                if failed_items[local_path] > 0:
+                    self.logger.warning("Download failed: LABEL: %s URL: %s (HTTP CODE %d)",
+                                        repo.content_set, urljoin(repo.repo_url, md_path),
+                                        failed_items[local_path])
         return failed
 
     def _download_metadata(self, batch):

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -180,7 +180,7 @@ class SyncHandler:
     def run_task_and_export(cls, *args, **kwargs):
         """Run sync task of current class and export."""
         result = cls.run_task(*args, **kwargs)
-        if cls not in (ExporterHandler, PkgTreeHandler, RepoListHandler):
+        if cls not in (ExporterHandler, PkgTreeHandler, RepoListHandler, GitRepoListHandler):
             ExporterHandler.run_task()
             PkgTreeHandler.run_task()
         return result
@@ -193,7 +193,7 @@ class SyncHandler:
     @classmethod
     def finish_task(cls, task_result):
         """Mark current task as finished."""
-        if cls not in (PkgTreeHandler, RepoListHandler):
+        if cls not in (PkgTreeHandler, RepoListHandler, GitRepoListHandler):
             # Notify webapps to update it's cache
             if ReposcanWebsocket.websocket:
                 ReposcanWebsocket.websocket.write_message("invalidate-cache")

--- a/reposcan/reposcan.spec.yaml
+++ b/reposcan/reposcan.spec.yaml
@@ -77,6 +77,19 @@ paths:
       tags:
         - Repos
 
+  /v1/repos/git:
+    put:
+      summary: Add repositories to the DB from git
+      operationId: reposcan.GitRepoListHandler.put
+      <<: *secured
+      responses:
+        <<: *repo_responses
+        <<: *running_resp
+        <<: *auth_resps
+        <<: *format_resps
+      tags:
+        - Repos
+
   /v1/repos/{repo}:
     delete:
       summary: Delete repo from the DB
@@ -109,16 +122,6 @@ paths:
                 $ref: "#/components/schemas/TaskStartResponse"
         <<: *running_resp
         <<: *auth_resps
-      tags:
-        - Sync
-
-  /v1/sync/repo/git:
-    put:
-      summary: Import repolist from git and perform repo sync
-      operationId: reposcan.GitRepoListHandler.put
-      <<: *secured
-      responses:
-        <<: *sync_responses
       tags:
         - Sync
 

--- a/reposcan/reposcan.spec.yaml
+++ b/reposcan/reposcan.spec.yaml
@@ -112,9 +112,19 @@ paths:
       tags:
         - Sync
 
+  /v1/sync/repo/git:
+    put:
+      summary: Import repolist from git and perform repo sync
+      operationId: reposcan.GitRepoListHandler.put
+      <<: *secured
+      responses:
+        <<: *sync_responses
+      tags:
+        - Sync
+
   /v1/sync/repo:
     put:
-      summary: Sync the package tree
+      summary: Sync repositories from imported repolist
       operationId: reposcan.RepoSyncHandler.put
       <<: *secured
       responses:
@@ -124,7 +134,7 @@ paths:
 
   /v1/sync/cve:
     put:
-      summary: Sync the package tree
+      summary: Sync the CVE list
       operationId: reposcan.CveSyncHandler.put
       <<: *secured
       responses:
@@ -134,7 +144,7 @@ paths:
 
   /v1/sync/cvemap:
     put:
-      summary: Sync the package tree
+      summary: Sync the CVE map
       operationId: reposcan.CvemapSyncHandler.put
       <<: *secured
       responses:


### PR DESCRIPTION
This PR adds a new SyncTask, which downloads repolist from github and imports it into database.

Before merging we have to figure out whether we want to create a new Openshift secret , or use existing `github-vulnerability-bot` secret for authorization against private repository.