### PR TITLE
Memory optimizations

### DIFF
--- a/reposcan/exporter.py
+++ b/reposcan/exporter.py
@@ -137,9 +137,14 @@ class DataDump:
                                """, [tuple(self.packagename_ids)])
                 src_pkg_id2pkg_ids = dict()
                 for pkg_id, name_id, evr_id, arch_id, summary, description, source_package_id in cursor:
-                    dump["package_details:%s" % pkg_id] = (name_id, evr_id, arch_id, summary, description,
-                                                           source_package_id)
+                    sum_id = hash(summary)
+                    desc_id = hash(description)
+                    dump["strings:%s" % sum_id] = summary
+                    dump["strings:%s" % desc_id] = description
+                    dump["package_details:%s" % pkg_id] = (name_id, evr_id, arch_id, sum_id, desc_id,
+                                                           source_package_id or 0)
                     dump["nevra2pkgid:%s:%s:%s" % (name_id, evr_id, arch_id)] = pkg_id
+
                     self.package_ids.append(pkg_id)
                     if source_package_id is not None:
                         src_pkg_id2pkg_ids.setdefault("src_pkg_id2pkg_ids:%s" % source_package_id, []).append(pkg_id)

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -683,7 +683,7 @@ def create_app():
     def metrics():  # pylint: disable=unused-variable
         # /metrics API shouldn't be visible in the API documentation,
         # hence it's added here in the create_app step
-        return generate_latest()
+        return generate_latest(), 200, {'Content-Type': 'text/plain; charset=utf-8'}
 
     @app.app.after_request
     def set_headers(response):  # pylint: disable=unused-variable

--- a/reposcan/test/test_exporter.py
+++ b/reposcan/test/test_exporter.py
@@ -95,7 +95,13 @@ class TestExporter:
     def check_package_details(self, dbdump):
         """Check package details in dump."""
         assert "package_details:301" in dbdump
-        assert dbdump["package_details:301"] == (101, 201, 1, "summary1", "description1", None)
+        item = dbdump["package_details:301"]
+        assert item[0] == 101
+        assert item[1] == 201
+        assert item[2] == 1
+        assert dbdump["strings:%s" % item[3]] == "summary1"
+        assert dbdump["strings:%s" % item[4]] == "description1"
+        assert not item[5]
 
     def check_repo(self, dbdump):
         """Check repo data in dump."""

--- a/webapp/cache.py
+++ b/webapp/cache.py
@@ -26,8 +26,8 @@ REPO_REVISION = 7
 PKG_NAME_ID = 0
 PKG_EVR_ID = 1
 PKG_ARCH_ID = 2
-PKG_SUMMARY = 3
-PKG_DESC = 4
+PKG_SUMMARY_ID = 3
+PKG_DESC_ID = 4
 PKG_SOURCE_PKG_ID = 5
 
 # cve detail indexes
@@ -66,7 +66,7 @@ ERRATA_URL = 13
 LOGGER = get_logger(__name__)
 
 
-def as_i64_arr(data):
+def as_long_arr(data):
     """Make a native i64 array from list of ints"""
     arr = array.array('q')
     arr.fromlist(data)
@@ -108,6 +108,7 @@ class Cache:
         self.dbchange = {}
         self.errata_detail = {}
         self.src_pkg_id2pkg_ids = {}
+        self.strings = {}
 
     def reload(self):
         """Update data and reload dictionaries."""
@@ -151,7 +152,7 @@ class Cache:
             elif relation == "arch_compat":
                 self.arch_compat[int(key)] = data[item]
             elif relation == "package_details":
-                self.package_details[int(key)] = data[item]
+                self.package_details[int(key)] = as_long_arr(list(data[item]))
             elif relation == "nevra2pkgid":
                 name_id, evr_id, arch_id = key.split(":", 2)
                 self.nevra2pkgid[(int(name_id), int(evr_id), int(arch_id))] = data[item]
@@ -162,11 +163,11 @@ class Cache:
             elif relation == "productid2repoids":
                 self.productid2repoids[int(key)] = data[item]
             elif relation == "pkgid2repoids":
-                self.pkgid2repoids[int(key)] = as_i64_arr(data[item])
+                self.pkgid2repoids[int(key)] = as_long_arr(list(data[item]))
             elif relation == "errataid2name":
                 self.errataid2name[int(key)] = data[item]
             elif relation == "pkgid2errataids":
-                self.pkgid2errataids[int(key)] = as_i64_arr(list(data[item]))
+                self.pkgid2errataids[int(key)] = as_long_arr(list(data[item]))
             elif relation == "errataid2repoids":
                 self.errataid2repoids[int(key)] = data[item]
             elif relation == "cve_detail":
@@ -183,6 +184,8 @@ class Cache:
                 self.modulename2id[(name, stream_name)] = data[item]
             elif relation == "src_pkg_id2pkg_ids":
                 self.src_pkg_id2pkg_ids[int(key)] = data[item]
+            elif relation == "strings":
+                self.strings[int(key)] = data[item]
             else:
                 raise KeyError("Unknown relation in data: %s" % relation)
         LOGGER.info("Loaded data version %s.", self.dbchange.get('exported', 'unknown'))

--- a/webapp/cache.py
+++ b/webapp/cache.py
@@ -5,6 +5,7 @@ Module to cache data from file dump.
 import dbm
 import os
 import shelve
+import array
 
 from common.logging_utils import get_logger
 
@@ -65,8 +66,16 @@ ERRATA_URL = 13
 LOGGER = get_logger(__name__)
 
 
+def as_i64_arr(data):
+    """Make a native i64 array from list of ints"""
+    arr = array.array('q')
+    arr.fromlist(data)
+    return arr
+
+
 class Cache:
     """ Cache class. """
+
     # pylint: disable=too-many-instance-attributes
     def __init__(self, filename=DUMP):
         self.filename = filename
@@ -153,11 +162,11 @@ class Cache:
             elif relation == "productid2repoids":
                 self.productid2repoids[int(key)] = data[item]
             elif relation == "pkgid2repoids":
-                self.pkgid2repoids[int(key)] = data[item]
+                self.pkgid2repoids[int(key)] = as_i64_arr(data[item])
             elif relation == "errataid2name":
                 self.errataid2name[int(key)] = data[item]
             elif relation == "pkgid2errataids":
-                self.pkgid2errataids[int(key)] = data[item]
+                self.pkgid2errataids[int(key)] = as_i64_arr(list(data[item]))
             elif relation == "errataid2repoids":
                 self.errataid2repoids[int(key)] = data[item]
             elif relation == "cve_detail":

--- a/webapp/packages.py
+++ b/webapp/packages.py
@@ -4,7 +4,7 @@ Module to handle /packages API calls.
 
 from jsonschema import validate
 
-from cache import REPO_LABEL, REPO_NAME, REPO_BASEARCH, REPO_RELEASEVER, PKG_SUMMARY, PKG_DESC, PKG_SOURCE_PKG_ID
+from cache import REPO_LABEL, REPO_NAME, REPO_BASEARCH, REPO_RELEASEVER, PKG_SUMMARY_ID, PKG_DESC_ID, PKG_SOURCE_PKG_ID
 import common.webapp_utils as utils
 
 JSON_SCHEMA = {
@@ -25,7 +25,7 @@ class PackagesAPI:
 
     def _get_source_package(self, pkg_detail):
         src_pkg_id = pkg_detail[PKG_SOURCE_PKG_ID]
-        if src_pkg_id is not None:
+        if src_pkg_id:
             src_pkg_detail = self.cache.package_details[src_pkg_id]
             src_pkg_nevra = utils.pkg_detail2nevra(self.cache, src_pkg_detail)
             return src_pkg_nevra
@@ -65,8 +65,8 @@ class PackagesAPI:
                 if (name_id, evr_id, arch_id) in self.cache.nevra2pkgid:
                     pkg_id = self.cache.nevra2pkgid[(name_id, evr_id, arch_id)]
                     pkg_detail = self.cache.package_details[pkg_id]
-                    packagedata['summary'] = pkg_detail[PKG_SUMMARY]
-                    packagedata['description'] = pkg_detail[PKG_DESC]
+                    packagedata['summary'] = self.cache.strings.get(pkg_detail[PKG_SUMMARY_ID], None)
+                    packagedata['description'] = self.cache.strings.get(pkg_detail[PKG_DESC_ID], None)
                     packagedata['source_package'] = self._get_source_package(pkg_detail)
                     packagedata['repositories'] = []
                     packagedata['package_list'] = self._get_built_binary_packages(pkg_id)

--- a/webapp/test/data/cache.yml
+++ b/webapp/test/data/cache.yml
@@ -130,42 +130,49 @@ nevra2pkgid:
   - 210
   - 5
   : 8210
+strings:
+  1: Testing package summary...
+  2: Testing package (1.1.0) description...
+  3: Testing package (1.2.0) description...
+  4: Testing package (2.0.0) summary...
+  5: Testing package description...
+  6: Testing package (2.1.0) summary...
 package_details:
   8110: !!python/tuple
   - 2222
   - 110
   - 5
-  - Testing package summary...
-  - Testing package (1.1.0) description...
+  - 1
+  - 2
   - 81100
   81100: !!python/tuple
   - 2222
   - 110
   - 6
-  - Testing source package summary...
-  - Testing source package (1.1.0) description...
-  - null
+  - 1
+  - 2
+  - 0
   8120: !!python/tuple
   - 2222
   - 120
   - 5
-  - Testing package summary...
-  - Testing package (1.2.0) description...
-  - null
+  - 1
+  - 3
+  - 0
   8200: !!python/tuple
   - 2222
   - 200
   - 5
-  - Testing package (2.0.0) summary...
-  - Testing package description...
-  - null
+  - 4
+  - 5
+  - 0
   8210: !!python/tuple
   - 2222
   - 210
   - 5
-  - Testing package (2.1.0) summary...
-  - Testing package description...
-  - null
+  - 6
+  - 5
+  - 0
 packagename2id:
   my-pkg: 2222
 pkgerrata2module:

--- a/webapp/test/test_cache.py
+++ b/webapp/test/test_cache.py
@@ -44,7 +44,7 @@ def test_cache(monkeypatch):
 
     cache.clear()
     variables = vars(cache)
-    assert len(variables) == 25
+    assert len(variables) == 26
     for name, var in variables.items():
         if name == "filename":
             assert var == TEST_DUMP_FILE

--- a/webapp/updates.py
+++ b/webapp/updates.py
@@ -7,7 +7,7 @@ import hashlib
 from jsonschema import validate
 
 from probes import HOT_CACHE_INSERTS, HOT_CACHE_REMOVAL, UPDATES_CACHE_HITS, UPDATES_CACHE_MISSES
-from cache import REPO_LABEL, REPO_BASEARCH, REPO_RELEASEVER, REPO_PRODUCT_ID, REPO_URL
+from cache import REPO_LABEL, REPO_BASEARCH, REPO_RELEASEVER, REPO_PRODUCT_ID, REPO_URL, PKG_SUMMARY_ID, PKG_DESC_ID
 from common.webapp_utils import join_packagename, split_packagename, none2empty
 
 
@@ -303,10 +303,12 @@ class UpdatesAPI:
                 continue
 
             if api_version == 1:
-                response['update_list'][pkg]['summary'] = \
-                    self.db_cache.package_details[current_nevra_pkg_id][3]
-                response['update_list'][pkg]['description'] = \
-                    self.db_cache.package_details[current_nevra_pkg_id][4]
+                sum_id = self.db_cache.package_details[current_nevra_pkg_id][PKG_SUMMARY_ID]
+                response['update_list'][pkg]['summary'] = self.db_cache.strings.get(sum_id, None)
+
+                desc_id = self.db_cache.package_details[current_nevra_pkg_id][PKG_DESC_ID]
+                response['update_list'][pkg]['description'] = self.db_cache.strings.get(desc_id, None)
+
             response['update_list'][pkg]['available_updates'] = []
 
             # No updates found for given NEVRA


### PR DESCRIPTION
- Store list[int] as raw long arrays, reduces memory usage by ~300 MB for production database.
- Deduplicate strings from package details and also store package_details as array , saves additional ~200 MB.
