### PR TITLE
Do not allocate node until stages start running

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,11 +10,8 @@
 // Code coverage failure threshold
 codecovThreshold = 89
 
-node {
-    // Cancel any prior builds that are running for this job
-    pipelineUtils.cancelPriorBuilds()
-    runStages()
-}
+pipelineUtils.cancelPriorBuilds()
+runStages()
 
 def deployVmaas(project) {
     gitUtils.withStatusContext("deploy") {


### PR DESCRIPTION
This should free up some slots on Jenkins master executor. Since we run with nested node calls like this:

```
node {
    openShiftUtils.withNode {
        lock
    }
}
```

If the job is waiting on a log, the executor on the master node gets held up for the duration of the job run. A node is not required to run `cancelPriorBuilds`.