### PR TITLE
chore: jenkinsfile path to tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ def runStages() {
                             LONG_RUNNING = "--long-running"
                         }
                         pytest_status = sh(
-                            script: "iqe tests plugin vulnerability -vvv -r s -k vmaas ${LONG_RUNNING} --html='report.html' --self-contained-html --generate-report",
+                            script: "iqe tests plugin vulnerability -vvv -r s -k vmaas/ ${LONG_RUNNING} --html='report.html' --self-contained-html --generate-report",
                             returnStatus: true
                         )
                         assert pytest_status <= 1 : "Pytest error: ${pytest_status}"


### PR DESCRIPTION
Without slash it runs also vulnerability tests because of jenkins workspace path @jdobes was too fast and merged it before my force push :smile: