### PR TITLE
feat(database): add database upgrade scripts and tutorial

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -17,6 +17,7 @@ ADD /reposcan/Pipfile*     /vmaas/reposcan/
 ADD /websocket/Pipfile*    /vmaas/websocket/
 ADD /webapp_utils/Pipfile* /vmaas/webapp_utils/
 ADD Pipfile*               /vmaas/
+ADD /database/upgrade_scripts/* /vmaas/reposcan/database/upgrade_scripts/
 
 ENV LC_ALL=en_US.utf8
 ENV LANG=en_US.utf8

--- a/database/README.md
+++ b/database/README.md
@@ -1,5 +1,15 @@
 # VMaaS Database service
 
+## VMaaS database upgrade system
+To perform an database upgrade to VMaaS, you need to create a sql file with given upgrade changes and also edit the same changes inside the ``` vmaas_db_postgresql.sql``` file. The upgrade is performed from reposcan container (```vmaas-reposcan```).  
+Step-by-step tutorial:
+* Increment the number in ``` vmaas_db_postgresql.sql```, inside table db_version and perform all patch changes
+* Create a SQL upgrade file
+  * File needs to have name notation like, ```XXX-upgrade_name.sql``` where the XXX is the latest number of database version that you already incremented inside ```vmaas_db_postgresql.sql``` file, upgrade_name should sign upgrade meaning.
+* There should not be any active running task in reposcan.
+* Launch ```dbupgrade.sh``` script from reposcan container (```docker exec -it vmaas-reposcan bash dbupgrade.sh```) 
+* Turn off the read-only mode in reposcan and turn on the vmaas-websocket. (```docker-compose start vmaas-websocket```)
+
 ### Build a new image:
 
 ```docker build -t vmaas_db_img .```

--- a/database/upgrade/dbupgrade.sh
+++ b/database/upgrade/dbupgrade.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd $(dirname $0)
+
+exec ./wait-for-services.sh python3 -m database.upgrade

--- a/database/upgrade_scripts/000-dbupgrades.sql
+++ b/database/upgrade_scripts/000-dbupgrades.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS db_version (
+  name TEXT NOT NULL,
+  version INT NOT NULL,
+  PRIMARY KEY (name)
+)TABLESPACE pg_default;
+
+-- Increment this when editing this file
+INSERT INTO db_version (name, version) VALUES ('schema_version', 0);
+
+CREATE TABLE db_upgrade_log IF NOT EXISTS (
+  id SERIAL,
+  version INT NOT NULL,
+  status TEXT NOT NULL,
+  script TEXT,
+  returncode INT,
+  stdout TEXT,
+  stderr TEXT,
+  last_updated TIMESTAMP WITH TIME ZONE NOT NULL
+) TABLESPACE pg_default;
+
+CREATE TRIGGER db_upgrade_log_set_last_updated
+  BEFORE INSERT OR UPDATE ON db_upgrade_log
+  FOR EACH ROW EXECUTE PROCEDURE set_last_updated();
+
+CREATE OR REPLACE FUNCTION set_last_updated()
+  RETURNS TRIGGER AS
+$set_last_updated$
+  BEGIN
+    IF (TG_OP = 'UPDATE') OR
+       NEW.last_updated IS NULL THEN
+      NEW.last_updated := CURRENT_TIMESTAMP;
+    END IF;
+    RETURN NEW;
+  END;
+$set_last_updated$
+  LANGUAGE 'plpgsql';
+

--- a/reposcan/Dockerfile
+++ b/reposcan/Dockerfile
@@ -39,5 +39,7 @@ ADD /reposcan/redhatcve/*.py /reposcan/redhatcve/
 ADD /reposcan/repodata/*.py  /reposcan/repodata/
 ADD /reposcan/rsyncd.conf    /etc/
 ADD /common/*.py             /reposcan/common/
+ADD /database/upgrade/*.sh   /reposcan/
+ADD /database/upgrade_scripts/* /reposcan/database/upgrade_scripts/
 
 CMD /reposcan/entrypoint.sh

--- a/reposcan/database/database_handler.py
+++ b/reposcan/database/database_handler.py
@@ -4,6 +4,11 @@ Module containing database handler class.
 import os
 import psycopg2
 
+DB_NAME = os.getenv('POSTGRESQL_DATABASE', "vmaas")
+DB_USER = os.getenv('POSTGRESQL_USER', "vmaas_writer")
+DB_PASS = os.getenv('POSTGRESQL_PASSWORD', "vmaas_writer_passwd")
+DB_HOST = os.getenv('POSTGRESQL_HOST', "database")
+DB_PORT = int(os.getenv('POSTGRESQL_PORT', "5432"))
 
 class NamedCursor:
     """Wrapper class for named cursor."""

--- a/reposcan/database/test/conftest.py
+++ b/reposcan/database/test/conftest.py
@@ -2,11 +2,20 @@
 
 import os
 
+from pathlib import Path
 import psycopg2
 import pytest
 import testing.postgresql
 
 from database.database_handler import init_db
+
+TEST_DIR = Path(__file__).resolve().parent
+REPOSCAN_DIR = (TEST_DIR.parent).parent
+VMAAS_DIR = (REPOSCAN_DIR.parent)
+VMAAS_DB_DIR = VMAAS_DIR.joinpath("database")
+
+VMAAS_PG = VMAAS_DB_DIR.joinpath("vmaas_db_postgresql.sql")
+VMAAS_USER = VMAAS_DB_DIR.joinpath("vmaas_user_create_postgresql.sql")
 
 os.environ["POSTGRESQL_DATABASE"] = "test"
 os.environ["POSTGRESQL_HOST"] = "127.0.0.1"
@@ -43,3 +52,32 @@ def db_conn():
     # teardown - close connection, stop postgresql
     conn.close()
     postgresql.stop()
+
+def create_pg(vmaas_user=VMAAS_USER, vmaas_pg=VMAAS_PG):
+    """ Create postgres instance with given SQL scripts. """
+    def _handler(postgresql):
+        """ Handler which intializes scheme in instance. """
+        conn = psycopg2.connect(**postgresql.dsn())
+
+        with conn.cursor() as cursor:
+            cursor.execute("DROP SCHEMA public CASCADE")
+            cursor.execute("CREATE SCHEMA public")
+            cursor.execute("GRANT ALL ON SCHEMA public TO postgres")
+            cursor.execute("GRANT ALL ON SCHEMA public TO public")
+
+        with conn.cursor() as cursor:
+            pg_env = postgresql.dsn()
+            cursor.execute("CREATE USER vmaas_db_admin WITH CREATEROLE")
+            cursor.execute("ALTER USER vmaas_db_admin WITH PASSWORD 'vmaas_db_admin_pwd'")
+            cursor.execute(f"ALTER DATABASE {pg_env['database']} OWNER TO vmaas_db_admin")
+
+        with conn.cursor() as cursor:
+            cursor.execute(vmaas_user.read_text())
+            cursor.execute(vmaas_pg.read_text())
+
+        conn.commit()
+
+    # pylint: disable=invalid-name
+    Postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=True, on_initialized=_handler)
+
+    return Postgresql

--- a/reposcan/database/test/test_upgrade.py
+++ b/reposcan/database/test/test_upgrade.py
@@ -1,0 +1,198 @@
+"""
+Tests for database upgrade, which are made from reposcan.
+"""
+# pylint: disable=no-self-use, import-outside-toplevel, unused-argument,
+import os
+import shutil
+import psycopg2
+import pytest
+
+DB_UPDATES_FIXTURE_PATH = "./dbfixtureupgrades"
+
+NAME = 0
+VALUE = 1
+
+VERSION = 0
+STATUS = 1
+SCRIPT = 2
+RETURNCODE = 3
+
+TEST_SCRIPT_1 = "CREATE TABLE TEST{}();"
+
+SCRIPT_COUNT = 10
+
+def _fetch_version(conn):
+    """ Fetch current version from db. """
+    with conn.cursor() as cursor:
+        cursor.execute("SELECT version FROM db_version")
+        return (cursor.fetchone())[0]
+
+def _fetch_version_logs(conn):
+    """ Fetch all upgrade logs from db. """
+    with conn.cursor() as cursor:
+        cursor.execute("SELECT version, status, script, returncode FROM db_upgrade_log")
+        return cursor.fetchall()
+
+def _fetch_upgrade_ver():
+    files = os.listdir(DB_UPDATES_FIXTURE_PATH)
+    latest = files[-1]
+    return int(latest.split("-")[0])
+
+def _create_script(version, script_content):
+    """ Create script with given version number and given script content. """
+    script_name = ("%0*d" % (3, version)) + "-test" + str(version) + ".sql"
+    script_path = os.path.join(DB_UPDATES_FIXTURE_PATH, script_name)
+    script_content = script_content.format(version)
+
+    with open(script_path, "w+") as new_script:
+        new_script.write(script_content)
+    return script_path
+
+def _remove_script(script_name):
+    """ Remove the test script. """
+    os.remove(script_name)
+
+def _parse_dsn(dsn_string):
+    """ Parsing of DSN string. """
+    port = None
+    host = None
+    user = None
+    db_name = None
+
+    params = dsn_string.split(" ")
+
+    for param in params:
+        name_value = param.split("=")
+        if name_value[NAME] == "port":
+            port = name_value[VALUE]
+        elif name_value[NAME] == "host":
+            host = name_value[VALUE]
+        elif name_value[NAME] == "user":
+            user = name_value[VALUE]
+        elif name_value[NAME] == "dbname":
+            db_name = name_value[VALUE]
+
+    return host, user, db_name, port
+
+class TestUpgrade:
+    """ Test for the upgrades. """
+
+    @pytest.fixture
+    def setup_teardown(self):
+        """ Fixture creates fixture folder for fixture upgrades. """
+        os.mkdir(DB_UPDATES_FIXTURE_PATH)
+        enviroment = dict(os.environ)
+        os.environ.clear()
+        yield
+        shutil.rmtree(DB_UPDATES_FIXTURE_PATH)
+        os.environ.update(enviroment)
+
+    def test_upgrade_empty(self, db_conn, setup_teardown):
+        """ Test with 0 upgrade tests. """
+        conn = db_conn
+
+        try:
+            current_version = int(_fetch_version(conn))
+        except psycopg2.ProgrammingError:
+            pytest.fail("Version cannot be fetched.")
+
+        # Reparse the connection string from the fixture, because
+        # upgrade script does upgrading with own connection & cursor
+        db_host, db_user, db_name, db_port = _parse_dsn(conn.dsn)
+
+        os.environ["POSTGRESQL_DATABASE"] = db_name
+        os.environ["POSTGRESQL_USER"] = db_user
+        os.environ["POSTGRESQL_HOST"] = db_host
+        os.environ["POSTGRESQL_PORT"] = db_port
+
+        from database import upgrade
+
+        os.environ["DB_UPGRADE_SCRIPTS_DIR"] = DB_UPDATES_FIXTURE_PATH
+        upgrade.main()
+
+        new_version = _fetch_version(conn)
+        assert new_version == current_version
+
+        logs = _fetch_version_logs(conn)
+        assert not logs
+
+    def test_upgrade_single(self, db_conn, setup_teardown):
+        """ Test with only single upgrade script. """
+        conn = db_conn
+
+        try:
+            current_version = int(_fetch_version(conn))
+        except psycopg2.ProgrammingError:
+            pytest.fail("Version cannot be fetched.")
+
+        test_version = current_version + 1
+        script_location = _create_script(test_version, TEST_SCRIPT_1)
+
+        # Reparse the connection string from the fixture, because
+        # upgrade script does upgrading with own connection & cursor
+        db_host, db_user, db_name, db_port = _parse_dsn(conn.dsn)
+
+        os.environ["POSTGRESQL_DATABASE"] = db_name
+        os.environ["POSTGRESQL_USER"] = db_user
+        os.environ["POSTGRESQL_HOST"] = db_host
+        os.environ["POSTGRESQL_PORT"] = db_port
+
+        from database import upgrade
+
+        os.environ["DB_UPGRADE_SCRIPTS_DIR"] = DB_UPDATES_FIXTURE_PATH
+
+        upgrade.main()
+
+        new_version = _fetch_version(conn)
+        assert new_version == test_version
+
+        logs = _fetch_version_logs(conn)
+        log = logs.pop()
+
+        assert log[VERSION] == test_version
+        assert log[STATUS] == "complete"
+        assert log[SCRIPT] == script_location.split("/")[-1]
+        assert log[RETURNCODE] == 0
+
+    def test_upgrade_multiple(self, db_conn, setup_teardown):
+        """ Test with multiple test upgrade scripts. """
+        conn = db_conn
+
+        try:
+            current_version = int(_fetch_version(conn))
+        except psycopg2.ProgrammingError:
+            pytest.fail("Version cannot be fetched.")
+
+        script_locations = []
+        max_script = current_version + SCRIPT_COUNT
+
+        for dummy_version in range(current_version, max_script + 1):
+            script_locations.append(_create_script(dummy_version, TEST_SCRIPT_1))
+
+        # Reparse the connection string from the fixture, because
+        # upgrade script does upgrading with own connection & cursor
+        db_host, db_user, db_name, db_port = _parse_dsn(conn.dsn)
+
+        os.environ["POSTGRESQL_DATABASE"] = db_name
+        os.environ["POSTGRESQL_USER"] = db_user
+        os.environ["POSTGRESQL_HOST"] = db_host
+        os.environ["POSTGRESQL_PORT"] = db_port
+
+        from database import upgrade
+
+        os.environ["DB_UPGRADE_SCRIPTS_DIR"] = DB_UPDATES_FIXTURE_PATH
+
+        upgrade.main()
+
+        new_version = int(_fetch_version(conn))
+        assert new_version == max_script
+
+        logs = _fetch_version_logs(conn)
+        script_num = 0
+        while script_num < max_script:
+            correct_result = (current_version + script_num,
+                              "complete",
+                              script_locations[script_num].split("/")[-1],
+                              0)
+            assert correct_result in logs
+            script_num += 1

--- a/reposcan/database/test/test_upgrader.py
+++ b/reposcan/database/test/test_upgrader.py
@@ -84,6 +84,7 @@ class TestUpgrade:
         enviroment = dict(os.environ)
         os.environ.clear()
         yield
+        os.environ.clear()
         shutil.rmtree(DB_UPDATES_FIXTURE_PATH)
         os.environ.update(enviroment)
 

--- a/reposcan/database/test/test_upgrades.py
+++ b/reposcan/database/test/test_upgrades.py
@@ -1,0 +1,162 @@
+"""
+Tests for database upgrade scripts.
+"""
+
+import subprocess
+import os
+import re
+import difflib
+import pytest
+from git import Repo
+from database.test.conftest import create_pg, VMAAS_DIR
+
+# pylint: disable=no-self-use
+# pylint: disable=unnecessary-comprehension
+
+UPGRADE_FROM = os.getenv("UPGRADE_FROM", "d38766771b2b5a23e1e33fcf94335b7a3b82444a")
+UPGRADE_TO = os.getenv("UPGRADE_TO", None)
+
+STATIC_TABLES = ["db_version"]
+
+def _dump_database(args):
+    """ Executes the process in args and returns output. """
+    dump = subprocess.check_output(args).decode("utf-8")
+    dump = re.sub(r",?\n+", "\n", dump).splitlines()
+    dump.sort()
+    return dump
+
+
+class TestUpgrades:
+    """ Tests for checking the upgrades in directory. """
+    repo = Repo(VMAAS_DIR)
+
+    if repo.head.is_detached:
+        head = repo.create_head(repo.head.commit.name_rev[:7], commit=repo.head.commit.hexsha)
+    else:
+        head = repo.head.reference
+
+    def _git_checkout(self, commit):
+        """ Perform git checkout specified by commit and stash current work. """
+        stashed = False
+        if self.repo.is_dirty():
+            self.repo.git.stash()
+            stashed = True
+
+        self.repo.head.reference = self.head
+        if commit:
+            self.repo.head.reference = self.repo.create_head(commit[:7], commit=commit)
+        self.repo.head.reset(index=True, working_tree=True)
+        return stashed
+
+    def _git_co_teardown(self, commit, stashed):
+        """ Performs teardown of git changes. """
+        self.repo.head.reference = self.head
+        self.repo.head.reset(index=True, working_tree=True)
+        if commit:
+            self.repo.delete_head(commit[:7])
+        if stashed:
+            self.repo.git.stash("pop")
+
+    @pytest.fixture(autouse=True)
+    def teardown(self):
+        """ Teardown for tests, saves the enviroment vars. """
+        enviroment = dict(os.environ)
+        os.environ.clear()
+        yield
+        os.environ.clear()
+        os.environ.update(enviroment)
+
+    @pytest.fixture
+    def pg_old(self, commit=UPGRADE_FROM):
+        """Setup DB with old schema."""
+        stashed = self._git_checkout(commit)
+        pg_factory = create_pg()
+        pg_instance = pg_factory()
+
+        yield pg_instance
+
+        pg_instance.stop()
+        pg_factory.clear_cache()
+        self._git_co_teardown(commit, stashed)
+
+    @pytest.fixture
+    def pg_new(self, commit=UPGRADE_TO):
+        """Setup DB with new schema."""
+        stashed = self._git_checkout(commit)
+        pg_factory = create_pg()
+        pg_instance = pg_factory()
+
+        yield pg_instance
+
+        pg_instance.stop()
+        pg_factory.clear_cache()
+        self._git_co_teardown(commit, stashed)
+
+    def test_upgrade(self, pg_old, pg_new):
+        """ Test the upgrades in folders. """
+        dsn_old = pg_old.dsn()
+        dsn_new = pg_new.dsn()
+
+        os.environ["POSTGRESQL_DATABASE"] = str(dsn_old["database"])
+        os.environ["POSTGRESQL_USER"] = "vmaas_db_admin"
+        os.environ["POSTGRESQL_HOST"] = str(dsn_old["host"])
+        os.environ["POSTGRESQL_PORT"] = str(dsn_old["port"])
+
+        # pylint: disable=import-outside-toplevel
+        from database import upgrade
+        upgrade.main()
+
+        schema_old_args = [
+            "pg_dump", "-s",
+            "-h", str(dsn_old["host"]),
+            "-p", str(dsn_old["port"]),
+            "-U", str(dsn_old["user"]),
+            "-d", str(dsn_old["database"])
+        ]
+
+        schema_new_args = [
+            "pg_dump", "-s",
+            "-h", str(dsn_new["host"]),
+            "-p", str(dsn_new["port"]),
+            "-U", str(dsn_new["user"]),
+            "-d", str(dsn_new["database"])
+        ]
+
+        dump_old = _dump_database(schema_old_args)
+        dump_new = _dump_database(schema_new_args)
+
+        try:
+            assert dump_old == dump_new
+        except AssertionError:
+            diff = difflib.unified_diff(dump_old, dump_new)
+            diffs = "\n".join([x for x in diff])
+            assert False, f"Diffs:\n{diffs}"
+
+        data_args = ["pg_dump", "-a"]
+        for table in STATIC_TABLES:
+            data_args.append("-t")
+            data_args.append(table)
+
+        data_old_args = data_args + [
+            "-h", str(dsn_old["host"]),
+            "-p", str(dsn_old["port"]),
+            "-U", str(dsn_old["user"]),
+            "-d", str(dsn_old["database"])
+        ]
+
+        data_new_args = data_args + [
+            "-h", str(dsn_new["host"]),
+            "-p", str(dsn_new["port"]),
+            "-U", str(dsn_new["user"]),
+            "-d", str(dsn_new["database"])
+        ]
+
+        old_data_dump = _dump_database(data_old_args)
+        new_data_dump = _dump_database(data_new_args)
+
+        try:
+            assert old_data_dump == new_data_dump
+        except AssertionError:
+            diff = difflib.unified_diff(old_data_dump, new_data_dump)
+            diffs = "\n".join([x for x in diff])
+            assert False, f"Diff:\n{diffs}"

--- a/reposcan/database/upgrade.py
+++ b/reposcan/database/upgrade.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+database upgrade
+"""
+
+import os
+import subprocess
+
+import psycopg2
+
+
+from database.database_handler import init_db, DatabaseHandler
+from common.logging_utils import init_logging, get_logger
+
+LOGGER = get_logger(__name__)
+
+SCHEMA_VER_NAME = 'schema_version'
+
+DB_UPGRADES_PATH = "./database/upgrade_scripts"
+
+class DatabaseUpgrade:
+    """ This class contains logic for upgrading the database.
+    """
+    # directory where the upgrade sql scripts are located.
+    # must end with '/' character.
+    scripts_dir = None
+
+    # map of version to which a script upgrades the db to
+    # the name of the script.
+    version2file_map = None
+
+    # highest version of a sql upgrade script.  This is the
+    # version to which the db will be upgraded.
+    version_max = 0
+
+    def __init__(self):
+        LOGGER.info('DatabaseUpgrade initializing.')
+
+        init_db()
+
+        # get upgrade sql scripts directory
+        self.scripts_dir = os.getenv('DB_UPGRADE_SCRIPTS_DIR',
+                                     DB_UPGRADES_PATH)
+        if not self.scripts_dir.endswith('/'):
+            self.scripts_dir += '/'
+
+        # load the version2file_map and version_max
+        self.version2file_map, self.version_max = self._load_upgrade_file_list(self.scripts_dir)
+
+    def upgrade(self):
+        """perform database upgrade"""
+        conn = DatabaseHandler.get_connection()
+        try:
+            self._get_db_lock(conn)
+
+            db_version = self._get_current_db_version(conn)
+
+            if db_version == self.version_max:
+                LOGGER.info('Database is up to date at version: %d', db_version)
+                return
+            if db_version > self.version_max:
+                msg = 'Database version %d is greater than upgrade version %d' % (db_version, self.version_max)
+                LOGGER.warning(msg)
+                return
+
+            LOGGER.info('Database requires upgrade from version %d to %d', db_version, self.version_max)
+            upgrades_to_apply = self._get_upgrades_to_apply(db_version, self.version_max)
+            for upgrade in upgrades_to_apply:
+                self._apply_upgrade(upgrade['ver'], upgrade['script'], conn)
+        finally:
+            self._release_db_lock(conn)
+
+    @staticmethod
+    def _load_upgrade_file_list(scripts_dir):
+        LOGGER.info('Building upgrade script list from directory %s', scripts_dir)
+        max_version = 0
+        ver2file_map = {}
+        files = os.listdir(scripts_dir)
+        for name in files:
+            if name.endswith('.sql'):
+                result = name.split('-', 1)
+                if len(result) != 2:
+                    LOGGER.info('ignoring file using different name format: %s', name)
+                else:
+                    try:
+                        file_num = int(result[0])
+                        if file_num in ver2file_map:
+                            raise Exception('Found two files with same file number',
+                                            ver2file_map[file_num],
+                                            name)
+                        LOGGER.debug('adding to list file version %d: %s', file_num, name)
+                        ver2file_map[file_num] = {'ver': file_num, 'script': name}
+                        if file_num > max_version:
+                            LOGGER.debug('max version raised to %d', file_num)
+                            max_version = file_num
+                    except ValueError:
+                        LOGGER.info('ignoring file with non-numeric prefix: %s', name)
+            else:
+                LOGGER.info('ignoring file without .sql suffix: %s', name)
+        return ver2file_map, max_version
+
+    def _get_upgrades_to_apply(self, current_ver, upgrade_ver):
+        upgrades_to_apply = []
+        missing_upgrades = []
+        for file_ver in range(current_ver + 1, upgrade_ver + 1):
+            if file_ver in self.version2file_map:
+                upgrades_to_apply.append(self.version2file_map[file_ver])
+            else:
+                missing_upgrades.append(file_ver)
+        if missing_upgrades:
+            raise Exception('Missing upgrade script versions %s' % missing_upgrades)
+        return upgrades_to_apply
+
+    def _apply_upgrade(self, version, script_file, conn):
+        LOGGER.info('applying upgrade to version %d', version)
+        if version > 1:
+            self._insert_log_entry(version, 'starting', script_file, conn)
+
+        psql_env = {'PGPASSWORD': DatabaseHandler.db_pass}
+        psql = subprocess.run(['/usr/bin/psql', '--no-password',
+                               '-h', DatabaseHandler.db_host,
+                               '-p', str(DatabaseHandler.db_port),
+                               '-U', DatabaseHandler.db_user,
+                               '-d', DatabaseHandler.db_name,
+                               '-f', self.scripts_dir + script_file],
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE,
+                              universal_newlines=True,
+                              env=psql_env,
+                              check=True)
+
+        if psql.returncode != 0 or psql.stderr:
+            status = 'failed'
+            failure = True
+            LOGGER.error('upgrade failure')
+        else:
+            status = 'complete'
+            failure = False
+            LOGGER.info('upgrade applied successfully')
+            self._set_current_db_version(version, conn)
+        self._insert_log_entry(version,
+                               status,
+                               script_file,
+                               conn,
+                               returncode=psql.returncode,
+                               stdout=psql.stdout,
+                               stderr=psql.stderr)
+        if failure:
+            raise Exception('upgrade psql command failed with returncode %d' % psql.returncode,
+                            'stdout: %s' % psql.stdout,
+                            'stderr: %s' % psql.stderr)
+
+    @staticmethod
+    def _get_db_lock(conn):
+        LOGGER.info('getting advisory lock')
+        with conn.cursor() as cur:
+            cur.execute('SELECT pg_advisory_lock(13)')
+        conn.commit()
+
+    @staticmethod
+    def _release_db_lock(conn):
+        LOGGER.info('releasing advisory lock')
+        with conn.cursor() as cur:
+            cur.execute('SELECT pg_advisory_unlock(13)')
+        conn.commit()
+
+    @staticmethod
+    def _get_current_db_version(conn):
+        try:
+            with conn.cursor() as cur:
+                cur.execute('select version from db_version where name = %s',
+                            (SCHEMA_VER_NAME,))
+                result = cur.fetchone()
+            if not result:
+                raise Exception("db_version table exists, but no row with name '%s'" % SCHEMA_VER_NAME)
+            db_version = result[0]
+        except psycopg2.ProgrammingError:
+            db_version = 0
+        finally:
+            conn.commit()
+        return db_version
+
+    @staticmethod
+    def _set_current_db_version(version, conn):
+        with conn.cursor() as cur:
+            cur.execute("update db_version set version = %s where name = %s",
+                        (version, SCHEMA_VER_NAME))
+
+        conn.commit()
+
+    @staticmethod
+    def _insert_log_entry(version, status, script, conn, returncode=None, stdout=None, stderr=None):
+        with conn.cursor() as cur:
+            cur.execute("""insert into db_upgrade_log
+                        (version, status, script, returncode, stdout, stderr)
+                        values (%s, %s, %s, %s, %s, %s)""",
+                        (version, status, script, returncode, stdout, stderr))
+        conn.commit()
+
+
+def main():
+    """Sets up and run whole application"""
+    # Set up endpoint for prometheus monitoring
+    init_logging()
+
+    upgrader = DatabaseUpgrade()
+    upgrader.upgrade()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Basically, the process is the same like for vulnerability-engine.

- The database upgrade scripts are placed into ```/database/upgrade_scripts/``` folder
- Sources for the database upgrade process are in ```/database/upgrade``` folder
- Upgrade script is started from the reposcan container and is placed in root folder of the container (```dbupgrade.sh```)
- Also I wrote some tutorial in ```README.md``` inside database folder