### PR TITLE
chore: ignore coverage of python modules in /usr

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,7 +187,7 @@ def runStages() {
                 
                 def status = 99
                 status = sh(
-                    script: "oc exec ${webapp_pod} -- coverage html --fail-under=${codecovThreshold} --omit /opt/\\* -d /tmp/htmlcov",
+                    script: "oc exec ${webapp_pod} -- coverage html --fail-under=${codecovThreshold} --omit /usr/\\* -d /tmp/htmlcov",
                     returnStatus: true
                 )
 

--- a/webapp/Dockerfile-qe
+++ b/webapp/Dockerfile-qe
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-RUN microdnf install python3 which rsync procps-ng shadow-utils && microdnf clean all
+RUN microdnf install python3 which rsync procps-ng shadow-utils tar && microdnf clean all
 
 WORKDIR /webapp
 


### PR DESCRIPTION
fixes coverage measurements after switching to UBI images