### PR TITLE
chore: use github actions for integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '*'
+      - '*/*'
+      - '!master'
+  pull_request:
+    branches:
+      - '*'
+      - '*/*'
+      - '!master'
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cancel previous builds
+        uses: rokroskar/workflow-run-cleanup-action@master
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Docker Login
+        uses: Azure/docker-login@v1
+        with:
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          login-server: quay.io
+      - name: Build and run VMaaS
+        run: docker-compose up --build -d
+      - name: Wait for VMaaS to run
+        run: |
+          set +e
+          resp=1
+          while [ "$resp" -ne 0 ]; do
+            curl http://localhost:8080/api/v1/monitoring/health
+            resp=$?
+          done
+      - name: Sync VMaaS repolist
+        run: ./scripts/setup_db.sh conf/repolist.json
+      - name: Run VMaaS integration tests
+        run: |
+          docker run --name iqe --network host \
+            -e IQE_TESTS_LOCAL_CONF_PATH=/iqe_settings ${{ secrets.IQE_TESTS_IMAGE }} \
+            iqe tests plugin vulnerability -k 'vmaas' --html=report.html --self-contained-html
+      - run: docker-compose logs > logs
+        if: always()
+      - run: docker cp iqe:/iqe_venv/report.html .
+        if: always()
+      - name: Publish test results
+        uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: test-report
+          path: report.html
+      - name: Publish logs
+        uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: docker-compose-logs
+          path: logs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,8 +10,10 @@
 // Code coverage failure threshold
 codecovThreshold = 89
 
-pipelineUtils.cancelPriorBuilds()
-runStages()
+if (env.BRANCH_NAME == 'master') {
+    pipelineUtils.cancelPriorBuilds()
+    runStages()
+}
 
 def deployVmaas(project) {
     gitUtils.withStatusContext("deploy") {

--- a/conf/repolist.json
+++ b/conf/repolist.json
@@ -1,0 +1,93 @@
+[{
+  "products": {
+    "Red Hat Enterprise Linux Server": {
+      "redhat_eng_product_id": 69,
+      "content_sets": {
+        "rhel-7-server-rpms": {
+          "name": "Red Hat Enterprise Linux 7 Server (RPMs)",
+          "baseurl": "https://raw.githubusercontent.com/psegedy/vmaas-data/master/repodata-for-vmaas/rhel/server/7/$releasever/$basearch/os/",
+          "basearch": ["x86_64", "ppc64"],
+          "releasever": ["7Server", "7.7"]
+        },
+        "rhel-8-for-x86_64-appstream-rpms": {
+          "name": "Red Hat Enterprise Linux 8.1 for x86_64 - AppStream (RPMs)",
+          "baseurl": "https://raw.githubusercontent.com/psegedy/vmaas-data/master/repodata-for-vmaas/rhel/$releasever/$basearch/appstream/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["8.1"]
+        }
+      }
+    },
+    "Red Hat Enterprise Linux Workstation": {
+      "content_sets": {
+        "rhel-7-workstation-rpms": {
+          "name": "Red Hat Enterprise Linux 7 Workstation (RPMs)",
+          "baseurl": "https://raw.githubusercontent.com/psegedy/vmaas-data/master/repodata-for-vmaas/rhel/workstation/7/$releasever/$basearch/os/",
+          "basearch": ["x86_64"],
+          "releasever": ["7Workstation"]
+        }
+      }
+    },
+    "VMaaS testing - same product": {
+      "content_sets": {
+        "vmaas-test-1": {
+          "name": "VMaaS testing repo 1 - arch2noar update",
+          "baseurl": "https://raw.githubusercontent.com/psegedy/vmaas-data/master/repodata-for-vmaas/vmaas-test-1/",
+          "basearch": ["x86_64"],
+          "releasever": ["7"]
+        },
+        "vmaas-test-2": {
+          "name": "VMaaS testing repo 2 - update in different repo",
+          "baseurl": "https://raw.githubusercontent.com/psegedy/vmaas-data/master/repodata-for-vmaas/vmaas-test-2/",
+          "basearch": ["x86_64"],
+          "releasever": ["7"]
+        }
+      }
+    },
+    "VMaaS testing - different product": {
+      "content_sets": {
+        "vmaas-test-3": {
+          "name": "VMaaS testing repo 3 - update in different repo - different product",
+          "baseurl": "https://raw.githubusercontent.com/psegedy/vmaas-data/master/repodata-for-vmaas/vmaas-test-3/",
+          "basearch": ["x86_64"],
+          "releasever": ["7"]
+        }
+      }
+    },
+    "VMaaS testing - empty basearch": {
+      "content_sets": {
+        "vmaas-test-4": {
+          "name": "VMaaS testing repo 4 - empty basearch (same repo as vmaas-test-3)",
+          "baseurl": "https://raw.githubusercontent.com/psegedy/vmaas-data/master/repodata-for-vmaas/vmaas-test-3/",
+          "basearch": [""],
+          "releasever": ["6"]
+        }
+      }
+    },
+    "VMaaS testing - architectures": {
+      "content_sets": {
+        "vmaas-test-i386": {
+          "name": "VMaaS testing i386 arch repo",
+          "baseurl": "https://raw.githubusercontent.com/psegedy/vmaas-data/master/repodata-for-vmaas/vmaas-test-arch-i386/",
+          "basearch": ["i386"],
+          "releasever": ["6"]
+        },
+        "vmaas-test-x86_64": {
+          "name": "VMaaS testing x86_64 arch repo",
+          "baseurl": "https://raw.githubusercontent.com/psegedy/vmaas-data/master/repodata-for-vmaas/vmaas-test-arch-x86_64/",
+          "basearch": ["x86_64"],
+          "releasever": ["7"]
+        }
+      }
+    },
+    "VMaaS testing - modularity": {
+      "content_sets": {
+        "vmaas-test-rhel8-module": {
+          "name": "VMaaS testing RHEL8 modularity repo",
+          "baseurl": "https://raw.githubusercontent.com/psegedy/vmaas-data/master/repodata-for-vmaas/module_repo/",
+          "basearch": ["x86_64"],
+          "releasever": ["8"]
+        }
+      }
+    }
+  }
+}]

--- a/scripts/setup_db.sh
+++ b/scripts/setup_db.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+USAGE="Usage:
+$0 REPOLIST_PATH [TARGET_HOSTNAME] [WEBAPP_HOSTNAME] [AUTH_TOKEN]
+
+Mandatory parameters:
+  REPOLIST_PATH   - Path to the repolist.json file
+
+Optional parameters:
+  TARGET_HOSTNAME - Hostname of the target machine where reposcan is running (default: localhost)
+  WEBAPP_HOSTNAME - Hostname of the target machine where webapp is running (default: localhost)
+  AUTH_TOKEN      - GitHub token for authentication
+"
+
+CHECK_PACKAGE="bash-4.2.45-5.el7_0.4.x86_64"
+
+wait_and_run() {
+  count=60
+  while [ "$count" -gt 0 ]; do
+    resp="$("$@")"
+    if [[ "$resp" != *"Another task already in progress"* && "$resp" != *'"running": true'* ]]; then
+      echo "$resp"
+      echo
+      break
+    fi
+    ((count--))
+    sleep 10
+  done
+  [ "$count" -gt 0 ] || exit 1
+}
+
+wait_for_cache() {
+  count=60
+  while [ "$count" -gt 0 ]; do
+    if curl -s "${webapp_url}/api/v1/updates/${CHECK_PACKAGE}" | grep -q '"erratum":'; then
+      echo "Cache refreshed"
+      break
+    fi
+    ((count--))
+    sleep 10
+  done
+  [ "$count" -gt 0 ] || exit 1
+}
+
+if [ "$#" -eq 0 ]; then
+  echo "$USAGE" >&2
+  exit 1
+fi
+
+if [[ -z "$2" || "$2" == "localhost" || "$2" == "127.0.0.1" ]]; then
+  url="http://localhost:8081"
+elif [[ "$2" != "http"* ]]; then
+  url="https://${2}"
+else
+  url="$2"
+fi
+
+if [[ -z "$3" || "$3" == "localhost" || "$3" == "127.0.0.1" ]]; then
+  webapp_url="http://localhost:8080"
+elif [[ "$2" != "http"* ]]; then
+  webapp_url="https://${3}"
+else
+  webapp_url="$3"
+fi
+
+if [ -n "$4" ]; then
+  token="$4"
+else
+  token="sometoken"
+fi
+headers=(-H "Authorization: token $token" -H "Content-type: application/json")
+
+printf "Step 1/4: Import Repos\nAPI Response: "
+wait_and_run curl -sS "${headers[@]}" -d "@${1}" -X POST "${url}/api/v1/repos"
+
+printf "Step 2/4: Repo + CVEmap + CVE sync\nAPI Response: "
+wait_and_run curl -sS "${headers[@]}" -X PUT "${url}/api/v1/sync"
+
+printf "Step 3/4 Check that no reposcan task is running\nAPI Response"
+wait_and_run curl -sS "${headers[@]}" -X GET "${url}/api/v1/task/status"
+
+echo "Step 4/4 Wait for webapp to load latest data and refresh cache"
+wait_for_cache
+
+echo "Done."


### PR DESCRIPTION
Use github actions instead of Jenkins for PR testing with integration tests. It builds docker-compose locally and executes vmaas tests from image with all iqe plugins installed.

Runs on every `push` event, even in your fork. It doesn't have to wait for previous deployment as Jenkins, but it needs some configuration for everyone who wants to make a PR.

__Needed configuration:__
- Set Secrets under Settings of your repository (fork).  Ping me (or I can send an e-mail) for values of following secrets
  - IQE_TESTS_IMAGE
  - REGISTRY_PASSWORD
  - REGISTRY_USERNAME
  - REPOLIST_JSON