### PR TITLE
Add autoscaler to webapp, format secrets as a list of yaml values

### DIFF
--- a/openshift/secrets.yml
+++ b/openshift/secrets.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 data:
   GIT_TOKEN: ""
@@ -5,7 +6,7 @@ kind: Secret
 metadata:
   name: github-vulnerability-bot
 type: Opaque
-
+---
 apiVersion: v1
 data:
   GIT_TOKEN: ""
@@ -13,7 +14,7 @@ kind: Secret
 metadata:
   name: github-vmaas-bot
 type: Opaque
-
+---
 apiVersion: v1
 data:
   DEFAULT_CA_CERT: ''

--- a/openshift/vmaas-webapp.yml
+++ b/openshift/vmaas-webapp.yml
@@ -76,6 +76,26 @@ objects:
     - name: latest
   status: {dockerImageRepository: ''}
 
+- apiVersion: autoscaling/v1
+  kind: HorizontalPodAutoscaler
+  metadata:
+    labels:
+      app: vmaas-${RELEASE}
+      component: vmaas-webapp-${RELEASE}
+    name: vmaas-webapp-${RELEASE}
+  spec:
+    scaleTargetRef:
+      apiVersion: apps.openshift.io/v1
+      kind: DeploymentConfig
+      name: vmaas-webapp-${RELEASE}
+      subresource: scale
+    minReplicas: 1
+    maxReplicas: 8
+    # Autoscaler takes the `requests` not limits into account
+    # Attempt to run at 0.5 cores per pod, and if there is a peak,
+    # use the remaining capacity to handle it.
+    targetCPUUtilizationPercentage: 100
+
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
@@ -162,7 +182,7 @@ objects:
           - {containerPort: 8080}
           resources:
             limits: {cpu: '1', memory: 2Gi}
-            requests: {cpu: 200m, memory: 2Gi}
+            requests: {cpu: 500m, memory: 2Gi}
           readinessProbe:
             httpGet:
               path: /api/v1/monitoring/health


### PR DESCRIPTION
- The HPA works with resource requests, not limits, so up the request to 0.5 of a core,
and make the autoscaler to keep the utilization on this value.

The autoscaler should add more pods when average utilization is > 0.5 
