### PR TITLE
feat(webapp): add lite error formatter

### DIFF
--- a/webapp/test/test_app.py
+++ b/webapp/test/test_app.py
@@ -228,6 +228,11 @@ class TestWebappGets(BaseCase):
         assert HTTPStatus.OK == resp.status
         assert resp.body == '{"cve_list": []}'
 
+    async def test_error_formatter(self):
+        """Test error formater"""
+        resp = await self.fetch('/api/v1/cves/*', method='GET')
+        assert HTTPStatus.BAD_REQUEST == resp.status
+        assert resp.body[24:] == '"detail": "error(\'nothing to repeat at position 1\',)", "status": 400}'
 
 @pytest.mark.usefixtures('client')
 class TestWebappSupportMethods(BaseCase):


### PR DESCRIPTION
The error formatter provided by connexion is not good at handling exceptions so I again created lighter version of error formatter. Also, I created a test so that the exceptions error formatter is tested in unit test and not only in integration tests.