### PR TITLE
don't block APIs when doing refresh and return 503 instead

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -56,6 +56,7 @@ class BaseHandler:
     pkgtree_api = None
     vulnerabilities_api = None
     dbchange_api = None
+    refreshing = False
 
     @classmethod
     async def get_post_data(cls, request):
@@ -67,6 +68,10 @@ class BaseHandler:
     @classmethod
     async def handle_request(cls, api_endpoint, api_version, param_name=None, param=None, **kwargs):
         """Takes care of validation of input and execution of request."""
+        # If refreshing cache, return 503 so apps can detect this state
+        if cls.refreshing:
+            return web.json_response("Data refresh in progress, please try again later.", status=503)
+
         request = kwargs.get('request', None)
         if request is None:
             raise ValueError('request not provided')
@@ -101,7 +106,7 @@ class BaseHandler:
         return web.json_response(res, status=code)
 
 
-class HealthHandler(BaseHandler):
+class HealthHandler:
     """Handler class providing health status."""
 
     @classmethod
@@ -117,7 +122,7 @@ class HealthHandler(BaseHandler):
         return web.Response(status=200)
 
 
-class VersionHandler(BaseHandler):
+class VersionHandler:
     """Handler class providing app version."""
 
     @classmethod
@@ -343,10 +348,12 @@ class Websocket:
     @staticmethod
     async def _refresh_cache():
         LOGGER.info("Starting cached data refresh.")
+        BaseHandler.refreshing = True
         await BaseHandler.db_cache.reload_async()
         use_hot_cache = os.getenv("HOTCACHE_ENABLED", "YES")
         if use_hot_cache.upper() == "YES":
             BaseHandler.updates_api.clear_hot_cache()
+        BaseHandler.refreshing = False
         LOGGER.info("Cached data refreshed.")
 
     async def websocket_loop(self):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -341,8 +341,9 @@ class Websocket:
         self.task = None
 
     @staticmethod
-    def _refresh_cache():
-        BaseHandler.db_cache.reload()
+    async def _refresh_cache():
+        LOGGER.info("Starting cached data refresh.")
+        await BaseHandler.db_cache.reload_async()
         use_hot_cache = os.getenv("HOTCACHE_ENABLED", "YES")
         if use_hot_cache.upper() == "YES":
             BaseHandler.updates_api.clear_hot_cache()
@@ -367,7 +368,7 @@ class Websocket:
                         latest_dump = await self.fetch_latest_dump()
                         if latest_dump != BaseHandler.db_cache.dbchange['exported']:
                             LOGGER.info("Fetching missed dump: %s.", latest_dump)
-                            self._refresh_cache()
+                            await self._refresh_cache()
                             msg = f"refreshed {BaseHandler.db_cache.dbchange['exported']}"
                             if self.websocket:
                                 await self.websocket.send_str(msg)
@@ -397,7 +398,7 @@ class Websocket:
                 return None
 
             if msg.data == 'refresh-cache':
-                self._refresh_cache()
+                await self._refresh_cache()
                 msg = f"refreshed {BaseHandler.db_cache.dbchange['exported']}"
                 if self.websocket:
                     await self.websocket.send_str(msg)

--- a/webapp/cache.py
+++ b/webapp/cache.py
@@ -6,6 +6,7 @@ import dbm
 import os
 import shelve
 import array
+import asyncio
 
 from common.logging_utils import get_logger
 
@@ -110,6 +111,11 @@ class Cache:
         self.src_pkg_id2pkg_ids = {}
         self.strings = {}
 
+    async def reload_async(self):
+        """Update data and reload dictionaries asynchronously."""
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self.reload)
+
     def reload(self):
         """Update data and reload dictionaries."""
         if self.download():
@@ -124,6 +130,7 @@ class Cache:
     def load(self, filename):
         """Load data from shelve file into dictionaries."""
         # pylint: disable=too-many-branches,too-many-statements
+        LOGGER.info("Loading cache dump...")
         try:
             data = shelve.open(filename, 'r')
         except dbm.error as err:
@@ -188,4 +195,4 @@ class Cache:
                 self.strings[int(key)] = data[item]
             else:
                 raise KeyError("Unknown relation in data: %s" % relation)
-        LOGGER.info("Loaded data version %s.", self.dbchange.get('exported', 'unknown'))
+        LOGGER.info("Loaded dump version: %s", self.dbchange.get('exported', 'unknown'))


### PR DESCRIPTION
- healthchecks won't fail because webapp stays responsive
- other apps can detect refreshing state by 503 code and retry instead of time out