### PR TITLE
Fix command in devel docker composes for podman-compose

### DIFF
--- a/docker-compose.devel-podman.yml
+++ b/docker-compose.devel-podman.yml
@@ -3,13 +3,7 @@ version: '3'
 services:
   vmaas_database:
     user: root
-    command:
-      - 'sh'
-      - '-c'
-      - 'chown -R postgres /var/lib/pgsql/data ; exec runuser postgres -c run-postgresql'
+    command: sh -c 'chown -R postgres /var/lib/pgsql/data ; exec runuser postgres -c run-postgresql'
   vmaas_reposcan:
     user: root
-    command:
-      - 'sh'
-      - '-c'
-      - 'chown -R vmaas /data ; exec sleep infinity'
+    command: sh -c 'chown -R vmaas /data ; exec sleep infinity'

--- a/docker-compose.devel.yml
+++ b/docker-compose.devel.yml
@@ -15,7 +15,7 @@ services:
     security_opt:
       - label=disable
     working_dir: /git
-    command: ["sleep", "infinity"]
+    command: sh -c "sleep infinity"
 
   vmaas_reposcan:
     volumes:
@@ -24,7 +24,7 @@ services:
     security_opt:
       - label=disable
     working_dir: /git
-    command: ["sleep", "infinity"]
+    command: sh -c "sleep infinity"
 
   vmaas_webapp:
     volumes:
@@ -33,7 +33,7 @@ services:
     security_opt:
       - label=disable
     working_dir: /git
-    command: ["sleep", "infinity"]
+    command: sh -c "sleep infinity"
 
   vmaas_webapp_utils:
     volumes:
@@ -42,7 +42,7 @@ services:
     security_opt:
       - label=disable
     working_dir: /git
-    command: ["sleep", "infinity"]
+    command: sh -c "sleep infinity"
 
   # we don't need grafana and prometheus in developer setup
   # let's them exit immediatelly


### PR DESCRIPTION
With podman-compose from Fedora 31 the command attribute from files docker-compose-devel* is not replaced by command from another file. The commands are joined. This fixes the commands to be replaced by command from another docker-compose file.