### PR TITLE
Fix rpms and srpms responses

### DIFF
--- a/webapp/rpm_pkg_names.py
+++ b/webapp/rpm_pkg_names.py
@@ -33,8 +33,6 @@ class RPMPkgNamesAPI:
                 content_set_ids = self._get_content_set_ids(pkg_name_id)
                 content_set_labels.extend(self._get_content_set_labels(content_set_ids, content_set_list))
                 content_data.setdefault(rpm, []).extend(natsorted(content_set_labels))
-            else:
-                content_data.setdefault(rpm, [])
 
         response['rpm_name_list'] = content_data
         return response

--- a/webapp/srpm_pkg_names.py
+++ b/webapp/srpm_pkg_names.py
@@ -64,8 +64,6 @@ class SRPMPkgNamesAPI:
 
                 if src_pkg_name_id in src_pkg_ids2names.values():
                     rpm_data.setdefault(srpm, {}).update(label2pkg_name_filtered)
-            else:
-                rpm_data.setdefault(srpm, {})
 
         response['srpm_name_list'] = rpm_data
         return response

--- a/webapp/test/test_rpm_pkg_names.py
+++ b/webapp/test/test_rpm_pkg_names.py
@@ -16,13 +16,15 @@ RPM_NAMES_JSON = {"rpm_name_list": [RPM]}
 RPM_SRPM_NAMES_JSON = {"rpm_name_list": [RPM]}
 RPM_CS_JSON = {"rpm_name_list": [RPM], "content_set_list": [CS_LABEL]}
 RPM_JSON_EMPTY_LIST = {"rpm_name_list": [""]}
-RPM_CS_JSON_EMPTY_LIST = {"rpm_name_list": [""], "content_set": [""]}
+RPM_CS_JSON_EMPTY_LIST = {"rpm_name_list": [""], "content_set_list": [""]}
 RPM_JSON_NON_EXIST = {"rpm_name_list": [NONE_EXIST]}
-RPM_CS_JSON_NON_EXIST = {"rpm_name_list": [NONE_EXIST], "content_set": [NONE_EXIST]}
+RPM_CS_JSON_NON_EXIST = {"rpm_name_list": [NONE_EXIST], "content_set_list": [NONE_EXIST]}
+RPM_CS_NONEXIST = {"rpm_name_list": [RPM], "content_set_list": [NONE_EXIST]}
 
 LAST_CHANGE = "2019-03-07T09:17:23.799995"
-EMPTY_RPM_RESPONSE = {"": []}
+EMPTY_RPM_RESPONSE = {}
 NON_EXIST_RPM_RESPONSE = {"none-exist": []}
+EXIST_RPM_RESPONSE_EMPTY_CS = {f"{RPM}": []}
 
 
 class TestRPMPkgNamesAPI(TestBase):
@@ -55,7 +57,12 @@ class TestRPMPkgNamesAPI(TestBase):
     def test_non_existing_rpms(self):
         """Test PackageNamesAPI with non existing rpms."""
         rpm_resp = self.package_names_api.process_list(1, RPM_JSON_NON_EXIST)
-        assert NON_EXIST_RPM_RESPONSE == rpm_resp['rpm_name_list']
+        assert EMPTY_RPM_RESPONSE == rpm_resp['rpm_name_list']
+
+    def test_noex_content_set_ex_srpm(self):
+        """Test PackageNamesAPI with existing rpm and nonexisting content set."""
+        rpm_resp = self.package_names_api.process_list(1, RPM_CS_NONEXIST)
+        assert EXIST_RPM_RESPONSE_EMPTY_CS == rpm_resp["rpm_name_list"]
 
     def test_last_change_in_resp(self):
         """Test PackageNamesAPI response contains last_change."""

--- a/webapp/test/test_srpm_pkg_names.py
+++ b/webapp/test/test_srpm_pkg_names.py
@@ -18,10 +18,11 @@ SRPM_JSON_EMPTY_LIST = {"srpm_name_list": [""]}
 SRPM_CS_JSON_EMPTY_LIST = {"srpm_name_list": [""], "content_set": [""]}
 SRPM_JSON_NON_EXIST = {"srpm_name_list": [NONE_EXIST]}
 SRPM_CS_JSON_NON_EXIST = {"srpm_name_list": [NONE_EXIST], "content_set": [NONE_EXIST]}
+SRPM_CS_NON_EXIST = {"srpm_name_list": [SRPM], "content_set": [NONE_EXIST]}
 
 LAST_CHANGE = "2019-03-07T09:17:23.799995"
 EMPTY_SRPM_RESPONSE = {"": {}}
-NON_EXIST_SRPM_RESPONSE = {"none-exist": {}}
+NON_EXIST_SRPM_RESPONSE = {"my-pkg": {}}
 
 
 class TestSRPMPkgNamesAPI(TestBase):
@@ -61,12 +62,17 @@ class TestSRPMPkgNamesAPI(TestBase):
     def test_non_existing_srpms(self):
         """Test PackageNamesAPI with non existing srpm."""
         srpm_resp = self.package_names_api.process_list(1, SRPM_JSON_NON_EXIST)
-        assert NON_EXIST_SRPM_RESPONSE == srpm_resp['srpm_name_list']
+        assert EMPTY_SRPM_RESPONSE == srpm_resp['srpm_name_list']
 
     def test_non_existing_content_set(self):
         """Test PackageNamesAPI with non existing srpm and content set."""
         srpm_cs_resp = self.package_names_api.process_list(1, SRPM_CS_JSON_NON_EXIST)
-        assert NON_EXIST_SRPM_RESPONSE == srpm_cs_resp['srpm_name_list']
+        assert EMPTY_SRPM_RESPONSE == srpm_cs_resp['srpm_name_list']
+
+    def test_noex_content_set_ex_srpm(self):
+        """Test PackageNamesAPI with existing srpm and nonexisting content set."""
+        srpm_resp = self.package_names_api.process_list(1, SRPM_CS_NON_EXIST)
+        assert NON_EXIST_SRPM_RESPONSE == srpm_resp["srpm_name_list"]
 
     def test_last_change_in_resp(self):
         """Test PackageNamesAPI response contains last_change."""

--- a/webapp/test/test_srpm_pkg_names.py
+++ b/webapp/test/test_srpm_pkg_names.py
@@ -15,14 +15,14 @@ NONE_EXIST = "none-exist"
 SRPM_NAMES_JSON = {"srpm_name_list": [SRPM]}
 SRPM_CS_JSON = {"srpm_name_list": [SRPM], "content_set_list": [CS_LABEL]}
 SRPM_JSON_EMPTY_LIST = {"srpm_name_list": [""]}
-SRPM_CS_JSON_EMPTY_LIST = {"srpm_name_list": [""], "content_set": [""]}
+SRPM_CS_JSON_EMPTY_LIST = {"srpm_name_list": [""], "content_set_list": [""]}
 SRPM_JSON_NON_EXIST = {"srpm_name_list": [NONE_EXIST]}
-SRPM_CS_JSON_NON_EXIST = {"srpm_name_list": [NONE_EXIST], "content_set": [NONE_EXIST]}
-SRPM_CS_NON_EXIST = {"srpm_name_list": [SRPM], "content_set": [NONE_EXIST]}
+SRPM_CS_JSON_NON_EXIST = {"srpm_name_list": [NONE_EXIST], "content_set_list": [NONE_EXIST]}
+SRPM_CS_NON_EXIST = {"srpm_name_list": [SRPM], "content_set_list": [NONE_EXIST]}
 
 LAST_CHANGE = "2019-03-07T09:17:23.799995"
-EMPTY_SRPM_RESPONSE = {"": {}}
-NON_EXIST_SRPM_RESPONSE = {"my-pkg": {}}
+EMPTY_SRPM_RESPONSE = {}
+NON_EXIST_SRPM_RESPONSE = {f"{SRPM}": {}}
 
 
 class TestSRPMPkgNamesAPI(TestBase):


### PR DESCRIPTION
- Now the package will be displayed as empty ("package_name" {}) only when it exists in the database.