### PR TITLE
chore: pipenv check workaround

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -30,6 +30,7 @@ ADD /common/*.py           /vmaas/webapp_utils/common/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN cd /vmaas/webapp && pipenv install --ignore-pipfile --deploy --dev && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check ; fi && \
     cd /vmaas/reposcan && pipenv install --ignore-pipfile --deploy --dev && \

--- a/reposcan/Dockerfile
+++ b/reposcan/Dockerfile
@@ -23,6 +23,7 @@ ADD /reposcan/Pipfile*       /reposcan/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -13,6 +13,7 @@ ADD /webapp/Pipfile* /webapp/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi

--- a/webapp/Dockerfile-qe
+++ b/webapp/Dockerfile-qe
@@ -9,6 +9,7 @@ ADD /webapp/Pipfile* /webapp/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ENV PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     cd /webapp && pipenv install --ignore-pipfile --deploy --system --dev && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi

--- a/webapp_utils/Dockerfile
+++ b/webapp_utils/Dockerfile
@@ -13,6 +13,7 @@ ADD /webapp_utils/Pipfile* /webapp_utils/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi

--- a/websocket/Dockerfile
+++ b/websocket/Dockerfile
@@ -13,7 +13,7 @@ ADD /websocket/Pipfile* /websocket/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
-
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi


### PR DESCRIPTION
https://github.com/pypa/pipenv/issues/4188

PIPENV_PYUP_API_KEY= can be removed when pipenv-2020.X.X is released