### PR TITLE
Removed updates when modules_list is not provided

### DIFF
--- a/webapp/test/data/cache.yml
+++ b/webapp/test/data/cache.yml
@@ -117,6 +117,8 @@ errataid2name:
 errataid2repoids:
   444: !!set
     1: null
+  556: !!set
+    2: null
 evr2id:
   ? &id001 !!python/tuple
   - '0'
@@ -317,7 +319,6 @@ pkgid2errataids:
   8310: !!set
     111: null
   8320: !!set
-    555: null
     556: null
 pkgid2repoids:
   8110:
@@ -328,11 +329,10 @@ pkgid2repoids:
   - 1
   8210:
   - 1
+  8310:
+  - 2
   8320:
   - 2
-  - 3
-  - 4
-  - 5
 productid2repoids:
   1: !!set
     1: null
@@ -391,6 +391,9 @@ updates:
   - 8120
   - 8200
   - 8210
+  332222:
+  - 8310
+  - 8320
 updates_index:
   2222:
     110:
@@ -401,6 +404,9 @@ updates_index:
     - 2
     210:
     - 3
+  332222:
+    310:
+    - 0
 src_pkg_id2pkg_ids:
   81100:
     - 8110

--- a/webapp/test/test_app.py
+++ b/webapp/test/test_app.py
@@ -122,7 +122,8 @@ class TestWebappPosts(BaseCase):
 
     async def test_vulnerabilities_post_1(self):
         """Test vulnerabilities post endpoint."""
-        body = """{"package_list": ["my-pkg-1.1.0-1.el8.i686"]}"""
+        body = """{"package_list": ["my-pkg-1.1.0-1.el8.i686"],
+                   "modules_list": [{"module_name": "my-pkg", "module_stream": "1"}]}"""
         resp = await self.fetch('/api/v1/vulnerabilities', method='POST', data=body)
         assert HTTPStatus.OK == resp.status
         assert resp.body[:30] == '{"cve_list": ["CVE-2014-1545"]'

--- a/webapp/test/test_app.py
+++ b/webapp/test/test_app.py
@@ -213,9 +213,9 @@ class TestWebappGets(BaseCase):
 
     async def test_vuln_get_1(self):
         """Test vulnerabilities get endpoint."""
-        resp = await self.fetch('/api/v1/vulnerabilities/my-pkg-1.1.0-1.el8.i686', method='GET')
+        resp = await self.fetch('/api/v1/vulnerabilities/kernel-rt-2.6.33.9-rt31.66.el6rt.x86_64', method='GET')
         assert HTTPStatus.OK == resp.status
-        assert resp.body[:30] == '{"cve_list": ["CVE-2014-1545"]'
+        assert resp.body[:30] == '{"cve_list": ["CVE-2018-10126"'
 
     async def test_vuln_get_2_tilda(self):
         """Test vulnerabilities get endpoint."""

--- a/webapp/test/test_cache.py
+++ b/webapp/test/test_cache.py
@@ -23,7 +23,7 @@ def test_cache(monkeypatch):
     assert len(cache.dbchange) == 5
     assert len(cache.errata_detail) == 4
     assert len(cache.errataid2name) == 4
-    assert len(cache.errataid2repoids) == 1
+    assert len(cache.errataid2repoids) == 2
     assert len(cache.evr2id) == 7
     assert len(cache.id2arch) == 3
     assert len(cache.id2evr) == 7
@@ -34,13 +34,13 @@ def test_cache(monkeypatch):
     assert len(cache.packagename2id) == 3
     assert len(cache.pkgerrata2module) == 5
     assert len(cache.pkgid2errataids) == 7
-    assert len(cache.pkgid2repoids) == 5
+    assert len(cache.pkgid2repoids) == 6
     assert len(cache.productid2repoids) == 1
     assert len(cache.repo_detail) == 5
     assert len(cache.repolabel2ids) == 1
     assert len(cache.src_pkg_id2pkg_ids) == 2
-    assert len(cache.updates) == 1
-    assert len(cache.updates_index) == 1
+    assert len(cache.updates) == 2
+    assert len(cache.updates_index) == 2
     assert len(cache.content_set_id2label) == 2
     assert len(cache.label2content_set_id) == 2
     assert len(cache.content_set_id2pkg_name_ids) == 2

--- a/webapp/test/test_modularity.py
+++ b/webapp/test/test_modularity.py
@@ -19,19 +19,19 @@ MODULE_JSONS = [{'module_name': 'my-pkg', 'module_stream': '1'},
                 {'module_name': 'sharks', 'module_stream': 'are_dangerous'}]
 
 OLD_OLD = [
-    ('without_modularity', None, {PKG_NEVRAS[1], PKG_NEVRAS[2], PKG_NEVRAS[3]}),
+    ('without_modularity', None, set()),
     ('with_modularity', [MODULE_JSONS[0]], {PKG_NEVRAS[1]}),
     ('multiple_modules', MODULE_JSONS, {PKG_NEVRAS[1], PKG_NEVRAS[2], PKG_NEVRAS[3]})
 ]
 
 NEW_OLD = [
-    ('without_modularity', None, {PKG_NEVRAS[2], PKG_NEVRAS[3]}),
+    ('without_modularity', None, set()),
     ('correct_stream_enabled', [MODULE_JSONS[0]], None),
     ('incorrect_stream_enabled', [MODULE_JSONS[1]], {PKG_NEVRAS[2], PKG_NEVRAS[3]})
 ]
 
 NEW_MODULE = [
-    ('without_modularity', None, {PKG_NEVRAS[3]}),
+    ('without_modularity', None, set()),
     ('with_modularity', [MODULE_JSONS[1]], {PKG_NEVRAS[3]})
 ]
 

--- a/webapp/test/test_pkgtree.py
+++ b/webapp/test/test_pkgtree.py
@@ -15,63 +15,35 @@ PKGS = ['kernel', 'kernel-rt']
 PKG_JSON = {"package_name_list": [PKG]}
 PKGS_JSON = {"package_name_list": PKGS}
 
-RESPONSE_PKG = {
-    'last_change': '2019-03-07T09:17:23.799995',
-    'package_name_list': {'kernel-rt': [{'errata': [{'issued': '2011-06-23T00:00:00',
-                                                     'name': 'RHEA-2011:0895'}],
-                                         'first_published': '2011-06-23T00:00:00',
-                                         'nevra': 'kernel-rt-2.6.33.9-rt31.66.el6rt.x86_64',
-                                         'repositories': []},
-                                        {'errata': [{'cve_list': ['CVE-2018-12126',
-                                                                  'CVE-2018-12127',
-                                                                  'CVE-2018-12130',
-                                                                  'CVE-2019-11091'],
-                                                     'issued': '2019-05-14T17:22:02',
-                                                     'name': 'RHSA-2019:1174'},
-                                                    {'cve_list': ['CVE-2018-10126'],
-                                                     'issued': '2019-06-14T18:22:02',
-                                                     'name': 'RHSA-2019:1175'}],
-                                         'first_published': '2019-05-14T17:22:02',
-                                         'nevra': 'kernel-rt-4.18.0-80.rt9.138.el8.x86_64',
-                                         'repositories': [{'basearch': 'x86_64',
-                                                           'label': 'rhel-8-for-x86_64-nfv-rpms',
-                                                           'name': 'Red Hat '
-                                                                   'Enterprise '
-                                                                   'Linux 8 for '
-                                                                   'x86_64 - Real '
-                                                                   'Time for NFV '
-                                                                   '(RPMs)',
-                                                           'releasever': '8.0',
-                                                           'revision': '2019-09-20T06:25:14+00:00'},
-                                                          {'basearch': 'x86_64',
-                                                           'label': 'rhel-8-for-x86_64-nfv-rpms',
-                                                           'name': 'Red Hat '
-                                                                   'Enterprise '
-                                                                   'Linux 8 for '
-                                                                   'x86_64 - Real '
-                                                                   'Time for NFV '
-                                                                   '(RPMs)',
-                                                           'releasever': '8.1',
-                                                           'revision': '2020-01-03T05:24:24+00:00'},
-                                                          {'basearch': 'x86_64',
-                                                           'label': 'rhel-8-for-x86_64-rt-rpms',
-                                                           'name': 'Red Hat '
-                                                                   'Enterprise '
-                                                                   'Linux 8 for '
-                                                                   'x86_64 - Real '
-                                                                   'Time (RPMs)',
-                                                           'releasever': '8.1',
-                                                           'revision': '2020-01-03T05:24:17+00:00'},
-                                                          {'basearch': 'x86_64',
-                                                           'label': 'rhel-8-for-x86_64-rt-rpms',
-                                                           'name': 'Red Hat '
-                                                                   'Enterprise '
-                                                                   'Linux 8 for '
-                                                                   'x86_64 - Real '
-                                                                   'Time (RPMs)',
-                                                           'releasever': '8.0',
-                                                           'revision': '2019-09-20T06:25:12+00:00'}]}]}
-}
+RESPONSE_PKG = {'last_change': '2019-03-07T09:17:23.799995',
+                'package_name_list': {'kernel-rt': [{'errata': [{'issued': '2011-06-23T00:00:00',
+                                                                 'name': 'RHEA-2011:0895'}],
+                                                     'first_published': '2011-06-23T00:00:00',
+                                                     'nevra': 'kernel-rt-2.6.33.9-rt31.66.el6rt.x86_64',
+                                                     'repositories': [{'basearch': 'x86_64',
+                                                                       'label': 'rhel-8-for-x86_64-rt-rpms',
+                                                                       'name': 'Red Hat '
+                                                                               'Enterprise '
+                                                                               'Linux 8 for '
+                                                                               'x86_64 - Real '
+                                                                               'Time (RPMs)',
+                                                                       'releasever': '8.1',
+                                                                       'revision': '2020-01-03T05:24:17+00:00'}]},
+                                                    {'errata': [{'cve_list': ['CVE-2018-10126'],
+                                                                 'issued': '2019-06-14T18:22:02',
+                                                                 'name': 'RHSA-2019:1175'}],
+                                                     'first_published': '2019-06-14T18:22:02',
+                                                     'nevra': 'kernel-rt-4.18.0-80.rt9.138.el8.x86_64',
+                                                     'repositories': [{'basearch': 'x86_64',
+                                                                       'label': 'rhel-8-for-x86_64-rt-rpms',
+                                                                       'name': 'Red Hat '
+                                                                               'Enterprise '
+                                                                               'Linux 8 for '
+                                                                               'x86_64 - Real '
+                                                                               'Time (RPMs)',
+                                                                       'releasever': '8.1',
+                                                                       'revision': '2020-01-03T05:24:17+00:00'}]}]}}
+
 
 RESPONSE_PKGS = {
     'last_change': '2019-03-07T09:17:23.799995',
@@ -180,16 +152,13 @@ class TestPkgtreeAPI(TestBase):
         # Errata
         response = self.pkg_api.process_list(1, PKG_JSON)
         erratas = response['package_name_list'][PKG][-1]['errata']
-        assert erratas[0]['name'] == 'RHSA-2019:1174'
-        assert erratas[1]['name'] == 'RHSA-2019:1175'
+        assert erratas[0]['name'] == 'RHSA-2019:1175'
         # CVE
-        assert erratas[0]['cve_list'] == ['CVE-2018-12126', 'CVE-2018-12127', 'CVE-2018-12130', 'CVE-2019-11091']
-        assert erratas[1]['cve_list'] == ['CVE-2018-10126']
+        assert erratas[0]['cve_list'] == ['CVE-2018-10126']
 
     def test_sorting_repositories(self):
         """Test sorting of repositories in pkgtree api response."""
         response = self.pkg_api.process_list(1, PKG_JSON)
         repos = [val['label'] for val in response['package_name_list'][PKG][-1]['repositories']]
-        expected = ['rhel-8-for-x86_64-nfv-rpms', 'rhel-8-for-x86_64-nfv-rpms',
-                    'rhel-8-for-x86_64-rt-rpms', 'rhel-8-for-x86_64-rt-rpms']
+        expected = ['rhel-8-for-x86_64-rt-rpms']
         assert repos == expected


### PR DESCRIPTION
- Updated not to return **modules related** updates, cves and erratas by default but only when modules_list is explicitly included into the request.
- Updated testing cache.yml to contain also non-module updates for better testing.
- Updated tests according to previous changes.