### PR TITLE
fix(reposcan): fixing ISE in prepare msg function

### DIFF
--- a/common/slack_notifications.py
+++ b/common/slack_notifications.py
@@ -45,11 +45,13 @@ def prepare_msg_for_slack(cert_name, header, expire_tuple=None):
     """Prepare msg_dict for format_message method"""
     msg = {'header': header,
            'name': cert_name if cert_name else 'None'}
-    (valid_to_dt, expire_in_days_td) = expire_tuple
 
-    if valid_to_dt and isinstance(expire_in_days_td, int):
-        msg['date'] = {'valid_to': valid_to_dt,
-                       'expire_in': 0 if expire_in_days_td < 0 else expire_in_days_td}
+    if expire_tuple:
+        (valid_to_dt, expire_in_days_td) = expire_tuple
+
+        if valid_to_dt and isinstance(expire_in_days_td, int):
+            msg['date'] = {'valid_to': valid_to_dt,
+                           'expire_in': 0 if expire_in_days_td < 0 else expire_in_days_td}
 
     return msg
 


### PR DESCRIPTION
reposcan: [ERROR] Internal server error <-9223363273888645507>'Traceback (most recent call last):\n  File "/vmaas/reposcan/repodata/repository_controller.py", line 81, in _check_cert_expiration_date\n    loaded_cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert)\n  File "/usr/local/lib/python3.6/site-packages/OpenSSL/crypto.py", line 1794, in load_certificate\n    _raise_current_error()\n  File "/usr/local/lib/python3.6/site-packages/OpenSSL/_util.py", line 54, in exception_from_error_queue\n    raise exception_type(errors)\nOpenSSL.crypto.Error: [(\'PEM routines\', \'get_name\', \'no start line\')]\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/vmaas/reposcan/reposcan.py", line 518, in run_task\n    repository_controller.store()\n  File "/vmaas/reposcan/repodata/repository_controller.py", line 272, in store\n    failed = self._download_repomds()\n  File "/vmaas/reposcan/repodata/repository_controller.py", line 72, in _download_repomds\n    self._check_cert_expiration_date(cert_name, cert)\n  File "/vmaas/reposcan/repodata/repository_controller.py", line 96, in _check_cert_expiration_date\n    msg = prepare_msg_for_slack(cert_name, \'Reposcan CDN certificate not provided or incorrect\')\n  File "/vmaas/reposcan/common/slack_notifications.py", line 48, in prepare_msg_for_slack\n    (valid_to_dt, expire_in_days_td) = expire_tuple\nTypeError: \'NoneType\' object is not iterable'|