### PR TITLE
chore: use redhat-actions/oc-installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,10 @@ jobs:
         run: |
           pip install -U pip
           pip install -r "${{ env.E2E_DEPLOY_PATH }}/requirements.txt"
-      - name: Download oc
-        run: |
-          mkdir oc
-          curl -L https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz | tar xz -C oc --strip-components=1
-          echo "::add-path::$GITHUB_WORKSPACE/oc"
+      - name: Install oc
+        uses: redhat-actions/oc-installer@v1
+        with:
+          oc_version: '3.11.154'
       - name: Docker Login
         uses: Azure/docker-login@v1
         with:


### PR DESCRIPTION
fixes 
```
Error: Unable to process command '::add-path::/home/runner/work/vmaas/vmaas/oc' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```