### PR TITLE
fix: waiting for DB and rsync port in e2e-deploy and docker-compose

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -28,6 +28,10 @@ class BaseConfig:
             "POSTGRESQL_READER_PASSWORD", "vmaas_reader_pwd"
         )
         self.pod_hostname = os.environ.get("HOSTNAME")
+        self.web_port = None
+        self.public_port = None
+        self.private_port = None
+        self.webapp_port = None
 
 
 # pylint: disable=too-many-instance-attributes
@@ -35,11 +39,11 @@ class Config(BaseConfig, metaclass=Singleton):
     """VMaaS configuration singleton."""
 
     def __init__(self):
+        super().__init__()
         if app_common_python.isClowderEnabled():
             self.clowder()
         else:
             self.legacy()
-        super().__init__()
 
     def clowder(self):
         """Configuration from Clowder."""
@@ -50,6 +54,7 @@ class Config(BaseConfig, metaclass=Singleton):
         self.db_pass = getattr(cfg.database, "password", "")
         self.db_host = getattr(cfg.database, "hostname", "")
         self.db_port = getattr(cfg.database, "port", "")
+        self.db_available = bool(self.db_name)
 
         self.cw_aws_access_key_id = cfg.logging.cloudwatch.accessKeyId
         self.cw_aws_secret_access_key = cfg.logging.cloudwatch.secretAccessKey
@@ -79,6 +84,7 @@ class Config(BaseConfig, metaclass=Singleton):
 
     def legacy(self):
         """Configuration fro environment variables."""
+        self.db_available = bool(os.getenv("POSTGRESQL_DATABASE"))
         self.db_name = os.getenv("POSTGRESQL_DATABASE", "vmaas")
         self.db_user = os.getenv("POSTGRESQL_USER", "vmaas_writer")
         self.db_pass = os.getenv("POSTGRESQL_PASSWORD", "vmaas_writer_pwd")
@@ -97,8 +103,3 @@ class Config(BaseConfig, metaclass=Singleton):
         self.reposcan_port = int(os.getenv("REPOSCAN_PORT", "8081"))
         self.webapp_port = "8080"
         self.remote_dump = f"rsync://{self.reposcan_host}:8730/data/vmaas.dbm"
-
-        # compatibility
-        self.web_port = None
-        self.public_port = None
-        self.private_port = None

--- a/docker-compose.devel.yml
+++ b/docker-compose.devel.yml
@@ -7,6 +7,7 @@ services:
     security_opt:
       - label=disable
     working_dir: /git
+    hostname: vmaas-database
 
   vmaas_websocket:
     volumes:
@@ -16,6 +17,7 @@ services:
       - label=disable
     working_dir: /git
     command: /vmaas/entrypoint.sh sleep
+    hostname: vmaas-websocket
 
   vmaas_reposcan:
     volumes:
@@ -25,6 +27,7 @@ services:
       - label=disable
     working_dir: /git
     command: /vmaas/entrypoint.sh sleep
+    hostname: vmaas-reposcan
 
   vmaas_webapp:
     volumes:
@@ -34,6 +37,7 @@ services:
       - label=disable
     working_dir: /git
     command: /vmaas/entrypoint.sh sleep
+    hostname: vmaas-webapp
 
   vmaas_webapp_utils:
     volumes:
@@ -43,6 +47,7 @@ services:
       - label=disable
     working_dir: /git
     command: /vmaas/entrypoint.sh sleep
+    hostname: vmaas-webapp-utils
 
   # we don't need grafana and prometheus in developer setup
   # let's them exit immediatelly

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   vmaas_database:
     container_name: vmaas-database
+    hostname: vmaas-database
     build:
         context: .
         dockerfile: ./database/Dockerfile.centos
@@ -19,6 +20,7 @@ services:
   vmaas_websocket:
     command: /vmaas/entrypoint.sh websocket
     container_name: vmaas-websocket
+    hostname: vmaas-websocket
     build:
         context: .
         dockerfile: ./Dockerfile
@@ -32,6 +34,7 @@ services:
   vmaas_reposcan:
     command: /vmaas/entrypoint.sh reposcan
     container_name: vmaas-reposcan
+    hostname: vmaas-reposcan
     image: vmaas/app:latest
     restart: unless-stopped
     env_file:
@@ -50,6 +53,7 @@ services:
   vmaas_webapp:
     command: /vmaas/entrypoint.sh webapp
     container_name: vmaas-webapp
+    hostname: vmaas-webapp
     image: vmaas/app:latest
     restart: unless-stopped
     env_file:
@@ -64,6 +68,7 @@ services:
   vmaas_webapp_utils:
     command: /vmaas/entrypoint.sh webapp-utils
     container_name: vmaas-webapp-utils
+    hostname: vmaas-webapp-utils
     image: vmaas/app:latest
     restart: unless-stopped
     env_file:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ if [[ ! -z $1 ]]; then
         [[ ! -z $QE_BUILD ]] && cmd="sleep infinity" || cmd="python3 -m main"
         exec python3 ../wait_for_services.py $cmd
     elif [[ "$1" == "reposcan" ]]; then
-        rsync --daemon --verbose --port=$(python3 -c "import app_common_python as a;print(a.LoadedConfig.privatePort)")
+        rsync --daemon --verbose --port=$(python3 -c "import app_common_python as a;print(a.LoadedConfig.privatePort or 8730)")
         cd reposcan
         exec python3 ../wait_for_services.py python3 -m main
     elif [[ "$1" == "websocket" ]]; then

--- a/wait_for_services.py
+++ b/wait_for_services.py
@@ -42,7 +42,7 @@ def main():
     init_logging()
     init_db()
     config = Config()
-    if config.db_name:
+    if config.db_available:
         wait(DatabaseHandler.get_connection, service="PostgreSQL")
     else:
         LOGGER.info("Skipping PostgreSQL check")


### PR DESCRIPTION
- fix waiting for DB when POSTGRESQL_DATABASE is not set
- fix rsync port when it is not deployed by Clowder
- add `hostname` to docker-compose, it is referenced in wait_for_services.py