### PR TITLE
chore: refactor and mirror health endpoint for clowder

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -25,20 +25,6 @@ objects:
         command:
           - /vmaas/entrypoint.sh
           - websocket
-        readinessProbe:
-          httpGet:
-            path: /api/v1/monitoring/health
-            port: 10000
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
-          periodSeconds: 10
-        livenessProbe:
-          httpGet:
-            path: /api/v1/monitoring/health
-            port: 10000
-          initialDelaySeconds: 120
-          timeoutSeconds: 1
-          periodSeconds: 60
         env:
         - name: CW_ENABLED
           value: ${{CW_ENABLED}}
@@ -62,22 +48,6 @@ objects:
         command:
           - /vmaas/entrypoint.sh
           - webapp
-        readinessProbe:
-          httpGet:
-            path: /api/v1/monitoring/ready
-            port: 8000
-          initialDelaySeconds: 0
-          timeoutSeconds: 3
-          periodSeconds: 1
-          failureThreshold: 1
-          successThreshold: 1
-        livenessProbe:
-          httpGet:
-            path: /api/v1/monitoring/health
-            port: 8000
-          initialDelaySeconds: 240
-          timeoutSeconds: 3
-          periodSeconds: 60
         env:
         - name: HOTCACHE_ENABLED
           valueFrom:
@@ -187,20 +157,6 @@ objects:
           name: vmaas-reposcan-tmp
         - mountPath: /data
           name: vmaas-dump-data
-        readinessProbe:
-          httpGet:
-            path: /api/v1/monitoring/health
-            port: 8000
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
-          periodSeconds: 10
-        livenessProbe:
-          httpGet:
-            path: /api/v1/monitoring/health
-            port: 8000
-          initialDelaySeconds: 120
-          timeoutSeconds: 1
-          periodSeconds: 60
         env:
         - name: BATCH_MAX_SIZE
           valueFrom:

--- a/reposcan/main.py
+++ b/reposcan/main.py
@@ -4,10 +4,12 @@ from tornado.ioloop import IOLoop
 from tornado.wsgi import WSGIContainer
 
 from common.config import Config
-from reposcan import create_app
+from reposcan import create_app, DEFAULT_PATH, DEFAULT_PATH_API
 
 # pylint: disable=invalid-name
-application = create_app()
+application = create_app({DEFAULT_PATH + "/v1": "reposcan.spec.yaml",
+                          DEFAULT_PATH_API + "/v1": "reposcan.spec.yaml",
+                          "": "reposcan.healthz.spec.yaml"})
 
 if __name__ == '__main__':
     cfg = Config()

--- a/reposcan/reposcan.healthz.spec.yaml
+++ b/reposcan/reposcan.healthz.spec.yaml
@@ -1,0 +1,22 @@
+openapi: '3.0.0'
+
+info:
+  title: VMaaS Reposcan
+  version: {{ vmaas_version }}
+
+paths:
+  /healthz:
+    get:
+      summary: Application availability
+      description: Check whether this application is live
+      operationId: reposcan.HealthHandler.get
+      x-methodName: getHealth
+      responses:
+        200:
+          description: Application available
+          content:
+            text/plain:
+              schema:
+                type: boolean
+                enum: [true, false]
+      tags: [ Metadata ]

--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -14,7 +14,6 @@ from multiprocessing.pool import Pool
 
 import connexion
 import git
-import yaml
 from flask import make_response
 from flask import request
 from flask import send_file
@@ -62,6 +61,9 @@ DEFAULT_CERT_NAME = "DEFAULT"
 DEFAULT_CA_CERT = os.getenv("DEFAULT_CA_CERT", "")
 DEFAULT_CERT = os.getenv("DEFAULT_CERT", "")
 DEFAULT_KEY = os.getenv("DEFAULT_KEY", "")
+
+DEFAULT_PATH_API = "/api"
+DEFAULT_PATH = "/api/vmaas"
 
 
 class TaskStatusResponse(dict):
@@ -744,7 +746,7 @@ def disabled_signals():
             signal.signal(sig, handlers[sig])
 
 
-def create_app():
+def create_app(specs):
     """Create reposcan app."""
 
     init_logging()
@@ -773,9 +775,6 @@ def create_app():
                                                      WEBSOCKET_RECONNECT_INTERVAL * 1000)
     ws_handler.reconnect_callback.start()
 
-    with open('reposcan.spec.yaml', 'rb') as specfile:
-        SPEC = yaml.safe_load(specfile)  # pylint: disable=invalid-name
-    SPEC['info']['version'] = VMAAS_VERSION
 
     app = connexion.App(__name__, options={
         'swagger_ui': True,
@@ -784,16 +783,14 @@ def create_app():
 
     # Response validation is disabled due to returing streamed response in GET /pkgtree
     # https://github.com/zalando/connexion/pull/467 should fix it
-    app.add_api(SPEC, resolver=connexion.RestyResolver('reposcan'),
-                validate_responses=False,
-                strict_validation=True,
-                base_path='/api/v1'
-                )
-    app.add_api(SPEC, resolver=connexion.RestyResolver('reposcan'),
-                validate_responses=False,
-                strict_validation=True,
-                base_path='/api/vmaas/v1'
-                )
+    for route, spec in specs.items():
+        app.add_api(spec, resolver=connexion.RestyResolver('reposcan'),
+                    validate_responses=False,
+                    strict_validation=True,
+                    base_path=route,
+                    arguments={"vmaas_version": VMAAS_VERSION}
+                    )
+
 
     @app.app.route('/metrics', methods=['GET'])
     def metrics():  # pylint: disable=unused-variable

--- a/reposcan/reposcan.spec.yaml
+++ b/reposcan/reposcan.spec.yaml
@@ -2,6 +2,7 @@ openapi: '3.0.0'
 
 info:
   title: VMaaS Reposcan
+  version: {{ vmaas_version }}
 
 x-format-resps: &format_resps
   400:

--- a/reposcan/test/test_case.py
+++ b/reposcan/test/test_case.py
@@ -37,7 +37,9 @@ class FlaskTestCase:
     @pytest.fixture
     def app(self):  # pylint: disable=no-self-use
         """Fixture for the application"""
-        connexion_app = reposcan.create_app()
+        connexion_app = reposcan.create_app({reposcan.DEFAULT_PATH + "/v1": "reposcan.spec.yaml",
+                                             reposcan.DEFAULT_PATH_API + "/v1": "reposcan.spec.yaml",
+                                             "": "reposcan.healthz.spec.yaml"})
         return connexion_app.app
 
     def fetch(self, path, **kwargs):

--- a/reposcan/test/test_run_reposcan.py
+++ b/reposcan/test/test_run_reposcan.py
@@ -7,6 +7,8 @@ from common.constants import VMAAS_VERSION
 def test_run_app(caplog):
     """Test reposcan init process."""
 
-    reposcan.create_app()
+    reposcan.create_app({reposcan.DEFAULT_PATH + "/v1": "reposcan.spec.yaml",
+                         reposcan.DEFAULT_PATH_API + "/v1": "reposcan.spec.yaml",
+                         "": "reposcan.healthz.spec.yaml"})
 
     assert f"Starting (version {VMAAS_VERSION})." in caplog.messages

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -1,6 +1,6 @@
 """Entry point for the application"""
 from aiohttp import web
-from app import create_app
+from app import create_app, DEFAULT_PATH, DEFAULT_PATH_API
 from app import init_websocket
 
 from common.config import Config
@@ -12,7 +12,12 @@ LOGGER = get_logger(__name__)
 if __name__ == '__main__':
     init_logging()
     # pylint: disable=invalid-name
-    application = create_app()
+    application = create_app({DEFAULT_PATH + "/v1": "webapp.v1.spec.yaml",
+                              DEFAULT_PATH + "/v2": "webapp.v2.spec.yaml",
+                              DEFAULT_PATH + "/v3": "webapp.v3.spec.yaml",
+                              DEFAULT_PATH_API + "/v1": "webapp.v1.spec.yaml",
+                              DEFAULT_PATH_API + "/v2": "webapp.v2.spec.yaml",
+                              DEFAULT_PATH_API + "/v3": "webapp.v3.spec.yaml"})
     init_websocket()
     cfg = Config()
     port = cfg.web_port or cfg.webapp_port

--- a/webapp/test/test_app.py
+++ b/webapp/test/test_app.py
@@ -7,14 +7,19 @@ from http import HTTPStatus
 from test import yaml_cache
 import pytest
 
-from app import create_app, BaseHandler, load_cache_to_apis
+from app import create_app, BaseHandler, load_cache_to_apis, DEFAULT_PATH, DEFAULT_PATH_API
 from common.constants import VMAAS_VERSION
 
 
 @pytest.fixture()
 async def server(aiohttp_server):
     """Setup testing app."""
-    app = create_app()
+    app = create_app({DEFAULT_PATH + "/v1": "webapp.v1.spec.yaml",
+                      DEFAULT_PATH + "/v2": "webapp.v2.spec.yaml",
+                      DEFAULT_PATH + "/v3": "webapp.v3.spec.yaml",
+                      DEFAULT_PATH_API + "/v1": "webapp.v1.spec.yaml",
+                      DEFAULT_PATH_API + "/v2": "webapp.v2.spec.yaml",
+                      DEFAULT_PATH_API + "/v3": "webapp.v3.spec.yaml"})
     BaseHandler.db_cache = yaml_cache.load_test_cache()
     load_cache_to_apis()
     return await aiohttp_server(app.app)

--- a/webapp/test/test_run_app.py
+++ b/webapp/test/test_run_app.py
@@ -10,6 +10,11 @@ def test_run_app(monkeypatch, caplog):
 
     monkeypatch.setattr(Cache, 'reload', lambda _: None)
 
-    app.create_app()
+    app.create_app({app.DEFAULT_PATH + "/v1": "webapp.v1.spec.yaml",
+                    app.DEFAULT_PATH + "/v2": "webapp.v2.spec.yaml",
+                    app.DEFAULT_PATH + "/v3": "webapp.v3.spec.yaml",
+                    app.DEFAULT_PATH_API + "/v1": "webapp.v1.spec.yaml",
+                    app.DEFAULT_PATH_API + "/v2": "webapp.v2.spec.yaml",
+                    app.DEFAULT_PATH_API + "/v3": "webapp.v3.spec.yaml"})
 
     assert f'Starting (version {VMAAS_VERSION}).' in caplog.messages

--- a/webapp/webapp.v1.spec.yaml
+++ b/webapp/webapp.v1.spec.yaml
@@ -3,6 +3,7 @@ openapi: '3.0.0'
 
 info:
   title: VMaaS Webapp
+  version: {{ vmaas_version }}
 
 
 x-format-resps: &format_resps

--- a/webapp/webapp.v2.spec.yaml
+++ b/webapp/webapp.v2.spec.yaml
@@ -3,6 +3,7 @@ openapi: '3.0.0'
 
 info:
   title: VMaaS Webapp
+  version: {{ vmaas_version }}
 
 
 x-format-resps: &format_resps

--- a/webapp/webapp.v3.spec.yaml
+++ b/webapp/webapp.v3.spec.yaml
@@ -3,6 +3,7 @@ openapi: '3.0.0'
 
 info:
   title: VMaaS Webapp
+  version: {{ vmaas_version }}
 
 
 x-format-resps: &format_resps

--- a/webapp_utils/webapp-utils-healthz.yml
+++ b/webapp_utils/webapp-utils-healthz.yml
@@ -1,0 +1,24 @@
+openapi: "3.0.0"
+
+info:
+  title: VMaaS Webapp Utilities
+  version: {{ vmaas_version }}
+
+paths:
+  /healthz:
+    get:
+      summary: Returns avaiability of the api.
+      operationId: health.GetHealth.get
+      responses:
+        200:
+          description: API is OK.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  health:
+                    type: string
+                    description: Health of the API.
+      tags:
+        - default

--- a/webapp_utils/webapp-utils.yml
+++ b/webapp_utils/webapp-utils.yml
@@ -2,6 +2,7 @@ openapi: "3.0.0"
 
 info:
   title: VMaaS Webapp Utilities
+  version: {{ vmaas_version }}
 
 servers: 
   - url: /api

--- a/websocket/websocket.py
+++ b/websocket/websocket.py
@@ -152,6 +152,7 @@ class WebsocketApplication(Application):
         handlers = [
             (r"/?", NotificationHandler),
             (r"/api/v1/monitoring/health/?", HealthHandler),
+            (r"/healthz/?", HealthHandler)
         ]
 
         Application.__init__(self, handlers, websocket_ping_interval=WEBSOCKET_PING_INTERVAL,


### PR DESCRIPTION
Healthz endpoint in webapp is added through aiohttp instance, because the connexion API does not allow having empty basepath for aiohttp.