### PR TITLE
feat(reposcan): accept lists for content set data

### DIFF
--- a/reposcan/reposcan.py
+++ b/reposcan/reposcan.py
@@ -222,10 +222,16 @@ class RepolistImportHandler(SyncHandler):
 
     @classmethod
     def _content_set_to_repos(cls, content_set):
+        all_repos = []
+
+        # Unpack list of content sets if provided
+        if isinstance(content_set, list):
+            for cset in content_set:
+                all_repos += cls._content_set_to_repos(cset)
+            return all_repos
         baseurls = content_set["baseurl"]
         basearches = content_set["basearch"]
         releasevers = content_set["releasever"]
-        all_repos = []
 
         # Accept a list or single baseurl
         if isinstance(baseurls, str):
@@ -277,7 +283,6 @@ class RepolistImportHandler(SyncHandler):
                     return None, None
                 for content_set_label, content_set in product["content_sets"].items():
                     products[product_name]["content_sets"][content_set_label] = content_set
-
                     for repo_url, basearch, releasever in cls._content_set_to_repos(content_set):
                         repos.append((repo_url, content_set_label, basearch, releasever,
                                       cert_name, ca_cert, cert, key))

--- a/reposcan/reposcan.spec.yaml
+++ b/reposcan/reposcan.spec.yaml
@@ -317,36 +317,43 @@ components:
         content_sets:
           type: object
           additionalProperties:
-            type: object
-            properties:
-              name:
-                type: string
-                example: Red Hat Enterprise Linux 6 Server (RPMs)
-              baseurl:
-                oneOf:
-                  - type: string
-                    example: https://cdn/content/dist/rhel/server/6/$releasever/$basearch/os/
-                  - type: array
-                    items:
-                      type: string
-                      example: https://cdn/content/dist/rhel/server/6/$releasever/$basearch/os/
-              basearch:
-                type: array
+            oneOf:
+              - $ref: '#/components/schemas/ContentItem'
+              - type: array
                 items:
-                  type: string
-                  example: x86_64
-              releasever:
-                type: array
-                items:
-                  type: string
-                  example: 6Server
-            required:
-            - name
-            - baseurl
-            - basearch
-            - releasever
+                  $ref: '#/components/schemas/ContentItem'
+
       required:
       - content_sets
+    ContentItem:
+      type: object
+      properties:
+        name:
+          type: string
+          example: Red Hat Enterprise Linux 6 Server (RPMs)
+        baseurl:
+          oneOf:
+            - type: string
+              example: https://cdn/content/dist/rhel/server/6/$releasever/$basearch/os/
+            - type: array
+              items:
+                type: string
+                example: https://cdn/content/dist/rhel/server/6/$releasever/$basearch/os/
+        basearch:
+          type: array
+          items:
+            type: string
+            example: x86_64
+        releasever:
+          type: array
+          items:
+            type: string
+            example: 6Server
+      required:
+        - name
+        - baseurl
+        - basearch
+        - releasever
     AddRepoItem:
       type: object
       properties:
@@ -380,7 +387,7 @@ components:
     ErrataObj:
       type: object
       properties:
-        name: { type: string, example: RHSA-2010:0842 }
+        name: { type: string, example: 'RHSA-2010:0842' }
         issued: { type: string, example: '2010-11-10T00:00:00+00:00', format: date-time }
         cve_list:
           type: array


### PR DESCRIPTION
Current approach results in issues when using multiple baseurls. This change adds multiple entries per one content set, and later pull request will remove support for multiple baseurls. (Result will be the same, but we will be able to choose what baseurl template should be applied to what releasevers within one content set).