### PR TITLE
chore: deploy vmaas component of vulnerability app

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -6,6 +6,7 @@
 APP_NAME="vulnerability"  # name of app-sre "application" folder this component lives in
 COMPONENT_NAME="vmaas"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 IMAGE="quay.io/cloudservices/vmaas-app"  
+COMPONENTS="vmaas"
 
 IQE_PLUGINS="vmaas"
 IQE_MARKER_EXPRESSION=""


### PR DESCRIPTION
`vmaas` and `vulnerability-engine` are defined as components of `vulnerability` app in `app-interface` repo. We need to deploy only `vmaas` to ephemeral env. 

https://github.com/RedHatInsights/bonfire/pull/58 allows to deploy selected components