### PR TITLE
chore(clowder): smooth transition with legacy ports

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -11,7 +11,7 @@ objects:
   spec:
     envName: ${ENV_NAME}
     deployments:
-    - name: websocket
+    - name: websocket-service
       minReplicas: ${{REPLICAS_WEBSOCKET}}
       webServices:
         public:
@@ -33,7 +33,7 @@ objects:
           limits: {cpu: 100m, memory: 100Mi}
           requests: {cpu: 100m, memory: 100Mi}
 
-    - name: webapp
+    - name: webapp-service
       minReplicas: ${{REPLICAS_WEBAPP}}
       webServices:
         public:
@@ -71,7 +71,7 @@ objects:
             cpu: 500m
             memory: 2Gi
 
-    - name: reposcan
+    - name: reposcan-service
       minReplicas: ${{REPLICAS_REPOSCAN}}
       webServices:
         public:
@@ -226,6 +226,55 @@ objects:
     name: github-vmaas-bot
     namespace: test
   type: Opaque
+
+# proxy requests for old service for smooth transition
+# vmaas-webapp:8080 to the clowderized one - vmaas-webapp-service:8000
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: vmaas-webapp
+    labels:
+      app: vmaas-webapp
+  spec:
+    ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8000
+      name: weblegacy
+    selector:
+      pod: vmaas-webapp-service
+# vmaas-websocket:8081 to the clowderized one - vmaas-websocket-service:9000
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: vmaas-websocket
+    labels:
+      app: vmaas-websocket
+  spec:
+    ports:
+    - port: 8082
+      protocol: TCP
+      targetPort: 9000
+      name: weblegacy
+    selector:
+      pod: vmaas-websocket-service
+
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    labels:
+      app: vmaas
+    name: webapp
+  spec:
+    port:
+      targetPort: 8000
+    tls:
+      termination: edge
+    to:
+      kind: Service
+      name: vmaas-webapp-service
+      weight: 100
+    wildcardPolicy: None
 
 parameters:
 - name: MEMORY_LIMIT


### PR DESCRIPTION
VULN-1909

for smoother transition, especially for Patch team if we deploy clowderized vmaas to prod sooner than Patch

and add an external route for vmaas like we used to have with old deployment