### PR TITLE
chore: signal handler takes 2 argmuents

### DIFF
--- a/wait_for_services.py
+++ b/wait_for_services.py
@@ -15,9 +15,9 @@ from vmaas.reposcan.database.database_handler import DatabaseHandler, init_db
 LOGGER = get_logger(__file__)
 
 
-def bye():
+def bye(signum, frame):
     """Handle signal"""
-    sys.exit("Stopped.")
+    sys.exit(f"Stopped,{signum} received.")
 
 
 def wait(func, *args, delay=1, service=""):


### PR DESCRIPTION
Traceback (most recent call last):
  File "../../wait_for_services.py", line 72, in <module>
    main()
  File "../../wait_for_services.py", line 61, in main
    service="Reposcan API"
  File "../../wait_for_services.py", line 35, in wait
    time.sleep(delay)
TypeError: bye() takes 0 positional arguments but 2 were given