### PR TITLE
fix(reposcan): skip populating empty repo data

### DIFF
--- a/vmaas/reposcan/database/modules_store.py
+++ b/vmaas/reposcan/database/modules_store.py
@@ -181,10 +181,11 @@ class ModulesStore(ObjectStore):
         # step.  Specifically _populate_modules and _populate_streams
         # could return modules with invalid/incomplete data.
         try:
-            modules = self._populate_modules(repo_id, modules)
-            modules = self._populate_streams(modules)
-            modules = self._populate_stream_requires(modules)
-            self._populate_rpm_artifacts(modules, repo_id)
+            if modules:
+                modules = self._populate_modules(repo_id, modules)
+                modules = self._populate_streams(modules)
+                modules = self._populate_stream_requires(modules)
+                self._populate_rpm_artifacts(modules, repo_id)
         except Exception: # pylint: disable=broad-except
             # exception already logged.
             pass

--- a/vmaas/reposcan/database/package_store.py
+++ b/vmaas/reposcan/database/package_store.py
@@ -180,8 +180,9 @@ class PackageStore(ObjectStore):
         """
         source_packages = self._get_source_packages(packages)
         self.logger.debug("Syncing %d packages.", len(packages))
-        self._populate_dependent_tables(source_packages + packages)
-        self._populate_packages(source_packages)
-        package_ids = self._populate_packages(packages)
-        self._associate_packages(package_ids, repo_id)
+        if packages:
+            self._populate_dependent_tables(source_packages + packages)
+            self._populate_packages(source_packages)
+            package_ids = self._populate_packages(packages)
+            self._associate_packages(package_ids, repo_id)
         self.logger.debug("Syncing packages finished.")

--- a/vmaas/reposcan/database/update_store.py
+++ b/vmaas/reposcan/database/update_store.py
@@ -368,11 +368,12 @@ class UpdateStore(ObjectStore):
         Import all updates from repository into all related DB tables.
         """
         self.logger.debug("Syncing %d updates.", len(updates))
-        update_map = self._populate_updates(updates)
-        self._associate_packages(updates, update_map, repo_id)
-        self._associate_source_packages(update_map)
-        self._associate_updates(update_map, repo_id)
-        cve_map = self._populate_cves(updates)
-        self._associate_cves(updates, update_map, cve_map)
-        self._associate_refs(updates, update_map)
+        if updates:
+            update_map = self._populate_updates(updates)
+            self._associate_packages(updates, update_map, repo_id)
+            self._associate_source_packages(update_map)
+            self._associate_updates(update_map, repo_id)
+            cve_map = self._populate_cves(updates)
+            self._associate_cves(updates, update_map, cve_map)
+            self._associate_refs(updates, update_map)
         self.logger.debug("Syncing updates finished.")


### PR DESCRIPTION
Causes postgres syntax error issues when some parts of repo are empty. For example:
```
2021-09-07 08:41:21,321:INFO:vmaas.reposcan.repodata.repository_controller:Syncing repository: rhel-7-server-rpms, ppc64, 7.7 [1/14]
2021-09-07 08:41:21,979:ERROR:vmaas.reposcan.database.object_store:Failure inserting into errata.'Traceback (most recent call last):\n  File "/vmaas/vmaas/reposcan/database/update_store.py", line 117, in _populate_updates\n    cur.execute("""select id, name from errata where name in %s""", (tuple(names),))\npsycopg2.errors.SyntaxError: syntax error at or near ")"\nLINE 1: select id, name from errata where name in ()\n                                                   ^\n'|
```

VMAAS-1378