### PR TITLE
VMAAS-1392: remove empty release versions from list

### DIFF
--- a/vmaas/webapp/errata.py
+++ b/vmaas/webapp/errata.py
@@ -83,9 +83,11 @@ class ErrataAPI:
         return ret
 
     def _errata_releasevers(self, errata_id):
-        releasevers = list(set(self.cache.repo_detail[rid][REPO_RELEASEVER]
-                               for rid in self.cache.errataid2repoids.get(errata_id, [])))
-        return list(releasevers)
+        releasevers = set(self.cache.repo_detail[rid][REPO_RELEASEVER]
+                          for rid in self.cache.errataid2repoids.get(errata_id, []))
+        # remove empty items and convert to list
+        releasevers = [x for x in releasevers if x is not None and x != '']
+        return releasevers
 
     def try_expand_by_regex(self, erratas: list) -> list:
         """Expand list with a POSIX regex if possible"""


### PR DESCRIPTION
fixing
"RHSA-2018:0512": { ...
 "release_versions": [ "6.10", "6.9", "6ComputeNode", "6Server", "6Client", "6Workstation", null ]
}