### PR TITLE
Set private port protocol to tcp for rsync

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -85,6 +85,7 @@ objects:
           enabled: true
         private:
           enabled: true
+          appProtocol: tcp
         metrics:
           enabled: true
       podSpec:


### PR DESCRIPTION
This resolves issues when deployed with Istio.
Do not merge yet until Clowder changes are pushed to Prod.