### PR TITLE
fix(vmaas-go): updates when releasever in repo is empty

### DIFF
--- a/vmaas-go/go.mod
+++ b/vmaas-go/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/redhatinsights/app-common-go v1.6.4
 	github.com/redhatinsights/platform-go-middlewares v0.20.0
-	github.com/redhatinsights/vmaas-lib v0.2.1
+	github.com/redhatinsights/vmaas-lib v0.2.2
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	github.com/zsais/go-gin-prometheus v0.1.0

--- a/vmaas-go/go.sum
+++ b/vmaas-go/go.sum
@@ -325,10 +325,8 @@ github.com/redhatinsights/app-common-go v1.6.4 h1:L6xhROlGEXN4zvw51whl+ZxtMN1fcs
 github.com/redhatinsights/app-common-go v1.6.4/go.mod h1:6gzRyg8ZyejwMCksukeAhh2ZXOB3uHSmBsbP06fG2PQ=
 github.com/redhatinsights/platform-go-middlewares v0.20.0 h1:qwK9ArGYRlORsZ56PXXLJrGvzTsMe3bk2lR+WN5aIjM=
 github.com/redhatinsights/platform-go-middlewares v0.20.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
-github.com/redhatinsights/vmaas-lib v0.2.0 h1:OfeBWGfhozBxzal9g0PAMfFzt3bFx3H6YE1a7WEkc50=
-github.com/redhatinsights/vmaas-lib v0.2.0/go.mod h1:Qq3Owvb0zbki8IuNBWyHRm5deJcgC3KTekkY+rhF18g=
-github.com/redhatinsights/vmaas-lib v0.2.1 h1:89YEYNrWS3AKDS6s//9er5OjNgxXjiFD3QJZV6PzdcA=
-github.com/redhatinsights/vmaas-lib v0.2.1/go.mod h1:Qq3Owvb0zbki8IuNBWyHRm5deJcgC3KTekkY+rhF18g=
+github.com/redhatinsights/vmaas-lib v0.2.2 h1:bEyVk75/ajiu8MM2+czDFImQgLgjByZLTwB8ae/SnD0=
+github.com/redhatinsights/vmaas-lib v0.2.2/go.mod h1:Qq3Owvb0zbki8IuNBWyHRm5deJcgC3KTekkY+rhF18g=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=


### PR DESCRIPTION
Updates were incorrect for repos with empty releasever, fixed by https://github.com/RedHatInsights/vmaas-lib/commit/3ec8712cdaa5638902ee1d2b6aecf31b3c3de0a8
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
