### PR TITLE
fix: inconsistent response for invalid packages

### DIFF
--- a/vmaas/common/webapp_utils.py
+++ b/vmaas/common/webapp_utils.py
@@ -122,6 +122,10 @@ def filter_package_list(package_list, latest_only=False):
     latest_pkgs = {}
     for pkg in package_list:
         name, epoch, ver, rel, arch = parse_rpm_name(pkg)
+        if not any((name, epoch, ver, rel, arch)):
+            # parse error - store `pkg` in `name` for consistency
+            # labelCompare would raise exception for such package
+            name = pkg
         if (name, arch) in latest_pkgs:
             latest = latest_pkgs[(name, arch)][0:3]
             if rpm.labelCompare((epoch, ver, rel), latest) < 1:  # pylint: disable=no-member


### PR DESCRIPTION
update for single invalid package (erp-handler-0:-.i386) returns:
  "update_list": {
    "erp-handler-0:-.i386": {}
  }

but when there are 2 invalid packages in the request, ("package_list": ["cel-handler-0:-.i386, erp-handler-0:-.i386"]) then it returns 400. the expected response is:
  "update_list": {
    "cel-handler-0:-.i386": {},
    "erp-handler-0:-.i386": {}
  }

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
