### PR TITLE
chore(vmaas-go) adjust cpu limit and gomaxprocs

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -66,11 +66,11 @@ objects:
           failureThreshold: 3
         resources:
           limits:
-            cpu: ${CPU_LIMIT_WEBAPP}
-            memory: ${MEMORY_LIMIT_WEBAPP}
+            cpu: ${CPU_LIMIT_WEBAPP_GO}
+            memory: ${MEMORY_LIMIT_WEBAPP_GO}
           requests:
-            cpu: ${CPU_REQUEST_WEBAPP}
-            memory: ${MEMORY_REQUEST_WEBAPP}
+            cpu: ${CPU_REQUEST_WEBAPP_GO}
+            memory: ${MEMORY_REQUEST_WEBAPP_GO}
 
     - name: webapp-service
       minReplicas: ${{REPLICAS_WEBAPP}}
@@ -344,6 +344,12 @@ parameters:
 - name: CPU_LIMIT_WEBAPP
   description: Maximum CPU limit for pod
   value: '1000m'
+- name: CPU_REQUEST_WEBAPP_GO
+  description: CPU request for pod
+  value: '1'
+- name: CPU_LIMIT_WEBAPP_GO
+  description: Maximum CPU limit for pod
+  value: '2'
 - name: CPU_REQUEST_REPOSCAN
   description: CPU request for pod
   value: '200m'
@@ -354,6 +360,12 @@ parameters:
   description: Memory request for pod
   value: '1536Mi'
 - name: MEMORY_LIMIT_WEBAPP
+  description: Maximum memory limit for pod
+  value: '3Gi'
+- name: MEMORY_REQUEST_WEBAPP_GO
+  description: Memory request for pod
+  value: '1536Mi'
+- name: MEMORY_LIMIT_WEBAPP_GO
   description: Maximum memory limit for pod
   value: '3Gi'
 - name: MEMORY_REQUEST_REPOSCAN
@@ -413,7 +425,7 @@ parameters:
   value: '1'
 - name: GOMAXPROCS_WEBAPP
   description: Maximum threads for webapp-go
-  value: '8'
+  value: '2'
 - name: GZIP_RESPONSE_ENABLE
   description: Sets GZIP compression in responses
   value: "on"


### PR DESCRIPTION
- add ability to set CPU/Memory requests/limits only for webapp-go
- set CPU limit = 2 to use parallelization at least for cache load
- GOMAXPROCS has to be set the same as the CPU limit (but it needs to be integer), higher gomaxprocs than cpu limit affects app performance, e.g. see benchmark in https://github.com/uber-go/automaxprocs#performance
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
