### PR TITLE
feat: store timestamp of last change of given repository

### DIFF
--- a/database/upgrade_scripts/016-repo_last_change.sql
+++ b/database/upgrade_scripts/016-repo_last_change.sql
@@ -1,0 +1,23 @@
+create or replace FUNCTION repo_last_change()
+  RETURNS TRIGGER AS
+$repo_last_change$
+  BEGIN
+    IF TG_OP = 'UPDATE' THEN
+      IF NEW.revision IS DISTINCT FROM OLD.revision THEN
+        NEW.last_change = CURRENT_TIMESTAMP;
+      END IF;
+    ELSIF TG_OP = 'INSERT' THEN
+      NEW.last_change = CURRENT_TIMESTAMP;
+    END IF;
+    RETURN NEW;
+  END;
+$repo_last_change$
+  LANGUAGE 'plpgsql';
+
+ALTER TABLE repo ADD COLUMN last_change TIMESTAMP WITH TIME ZONE;
+UPDATE repo SET last_change = CURRENT_TIMESTAMP;
+ALTER TABLE repo ALTER COLUMN last_change SET NOT NULL;
+
+CREATE TRIGGER repo_last_change BEFORE INSERT OR UPDATE ON repo
+  FOR EACH ROW
+  EXECUTE PROCEDURE repo_last_change();

--- a/vmaas/reposcan/exporter.py
+++ b/vmaas/reposcan/exporter.py
@@ -295,6 +295,7 @@ class SqliteDump:
                                 product text,
                                 product_id integer,
                                 revision text,
+                                last_change text,
                                 third_party integer
                                )""")
         # Select repo detail mapping
@@ -308,6 +309,7 @@ class SqliteDump:
                                       p.name as product_name,
                                       p.id as product_id,
                                       r.revision,
+                                      r.last_change,
                                       cs.third_party
                                  from repo r
                                  join content_set cs on cs.id = r.content_set_id
@@ -315,12 +317,13 @@ class SqliteDump:
                                  join product p on p.id = cs.product_id
                                  """)
             for oid, label, name, url, basearch, releasever, \
-                    product, product_id, revision, third_party in cursor:
-                dump.execute("insert into repo_detail values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    product, product_id, revision, last_change, third_party in cursor:
+                dump.execute("insert into repo_detail values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                              (oid, label, name, url, basearch,
                               releasever, product, product_id,
                               # Use NULLs in export
                               format_datetime(revision) if revision is not None else None,
+                              format_datetime(last_change),
                               1 if third_party else 0),)
 
         dump.execute("""create table if not exists pkg_repo (

--- a/vmaas/webapp/cache.py
+++ b/vmaas/webapp/cache.py
@@ -256,7 +256,8 @@ class Cache:
             if src_pkg_id:
                 self.src_pkg_id2pkg_ids.setdefault(src_pkg_id, array.array('q')).append(id)
 
-        for row in self._sqlite_execute(data, "select * from repo_detail"):
+        for row in self._sqlite_execute(data, """select id, label, name, url, basearch, releasever,
+                                                 product, product_id, revision, third_party from repo_detail"""):
             id = row[0]
             url = row[3]
             repo = (row[1], row[2], url, row[4], row[5], row[6], row[7],


### PR DESCRIPTION
## Description
Lets store the last change of every repository done by vmaas. So that in vmaas-sync for Patch/Vulnerability, we can use this timestamp instead of "revision" timestamp for `modified_since` parameter. Since the revision timestamp is not in "our hands" to modify and by this new timestamp we can detect timestamp when repo changed in vmaas (and not in RedHat CDN).



## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
