### PR TITLE
chore: replace strtobool by custom impl

### DIFF
--- a/vmaas/common/config.py
+++ b/vmaas/common/config.py
@@ -2,9 +2,10 @@
 Common VMaaS configuration.
 """
 import os
-from distutils.util import strtobool
 
 import app_common_python
+
+from vmaas.common.strtobool import strtobool
 
 
 class Singleton(type):

--- a/vmaas/common/logging_utils.py
+++ b/vmaas/common/logging_utils.py
@@ -6,7 +6,6 @@ TODO: packaging changes that let this live in one place please
 import logging
 import os
 import time
-from distutils.util import strtobool  # pylint: disable=import-error, no-name-in-module
 from threading import Lock
 
 import watchtower
@@ -14,6 +13,7 @@ from boto3 import client
 from botocore.exceptions import ClientError
 
 from vmaas.common.config import Config
+from vmaas.common.strtobool import strtobool
 
 
 class OneLineExceptionFormatter(logging.Formatter):

--- a/vmaas/common/strtobool.py
+++ b/vmaas/common/strtobool.py
@@ -1,0 +1,21 @@
+"""Module providing `strtobool` function as replacement of distutils.strtobool."""
+
+
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to bool.
+
+    True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0.
+    Raises TypeError if `val` is not string.
+    Raises ValueError if `val` is anything else.
+    """
+    if not isinstance(val, str):
+        raise TypeError(f"`{val}` is not of type str")
+    trues = ("y", "yes", "t", "true", "on", "1")
+    falses = ("n", "no", "f", "false", "off", "0")
+
+    val = val.lower()
+    if val in trues:
+        return True
+    if val in falses:
+        return False
+    raise ValueError(f"`{val}` not in {trues + falses}")

--- a/vmaas/reposcan/redhatcsaf/csaf_controller.py
+++ b/vmaas/reposcan/redhatcsaf/csaf_controller.py
@@ -4,11 +4,11 @@ Module containing class for syncing set of CSAF files into the DB.
 import os
 import shutil
 import tempfile
-from distutils.util import strtobool
 from pathlib import Path
 
 from vmaas.common.batch_list import BatchList
 from vmaas.common.logging_utils import get_logger
+from vmaas.common.strtobool import strtobool
 from vmaas.reposcan.database.csaf_store import CsafStore
 from vmaas.reposcan.download.downloader import DownloadItem
 from vmaas.reposcan.download.downloader import FileDownloader

--- a/vmaas/reposcan/redhatoval/oval_controller.py
+++ b/vmaas/reposcan/redhatoval/oval_controller.py
@@ -6,11 +6,11 @@ import shutil
 import tempfile
 import json
 import re
-from distutils.util import strtobool
 
 from vmaas.common.batch_list import BatchList
 from vmaas.common.logging_utils import get_logger
 from vmaas.common.date_utils import parse_datetime
+from vmaas.common.strtobool import strtobool
 
 from vmaas.reposcan.database.oval_store import OvalStore
 from vmaas.reposcan.download.downloader import FileDownloader, DownloadItem, VALID_HTTP_CODES

--- a/vmaas/reposcan/repodata/updateinfo.py
+++ b/vmaas/reposcan/repodata/updateinfo.py
@@ -4,12 +4,12 @@ Module containing class for UpdateInfo XML metadata.
 # pylint: disable=too-many-nested-blocks, too-many-branches
 # I really don't want to do that but, the way how updateinfo XML is done it's unfortuntately needed
 from datetime import datetime
-from distutils.util import strtobool
 import re
 import xml.etree.ElementTree as eT
 
 from vmaas.common.string import text_strip
 from vmaas.common.utc import UTC
+from vmaas.common.strtobool import strtobool
 
 DATETIME_PATTERNS = {
     "%Y-%m-%d %H:%M:%S": re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"),

--- a/vmaas/reposcan/reposcan.py
+++ b/vmaas/reposcan/reposcan.py
@@ -13,7 +13,6 @@ import signal
 from contextlib import contextmanager
 from multiprocessing.pool import Pool
 from functools import reduce
-from distutils.util import strtobool
 
 import connexion
 import git
@@ -24,6 +23,7 @@ from psycopg2 import DatabaseError
 
 from vmaas.common.constants import VMAAS_VERSION
 from vmaas.common.logging_utils import get_logger, init_logging
+from vmaas.common.strtobool import strtobool
 from vmaas.reposcan.database.database_handler import DatabaseHandler, init_db
 from vmaas.reposcan.database.product_store import ProductStore
 from vmaas.reposcan.dbchange import DbChangeAPI

--- a/vmaas/webapp/app.py
+++ b/vmaas/webapp/app.py
@@ -9,7 +9,6 @@ import signal
 import sre_constants
 import ssl
 import time
-from distutils.util import strtobool
 from json import loads
 
 import connexion
@@ -38,6 +37,7 @@ from vmaas.webapp.vulnerabilities import VulnerabilitiesAPI
 from vmaas.common.config import Config
 from vmaas.common.constants import VMAAS_VERSION
 from vmaas.common.logging_utils import get_logger
+from vmaas.common.strtobool import strtobool
 
 # pylint: disable=too-many-lines
 CFG = Config()


### PR DESCRIPTION
use same strtobool implementation as we are using in vulnerability-engine
- distutils is deprecated since python3.10
- distutils.util.strtobool returns int instead of bool
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
