### PR TITLE
build: Add --no-cache option to build deploy

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -22,7 +22,7 @@ export REGISTRY_AUTH_FILE="$AUTH_CONF_DIR/auth.json"
 
 podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
-podman build --build-arg STATIC_ASSETS=1 --pull=true -f Dockerfile -t "${IMAGE}:${IMAGE_TAG}" .
+podman build --no-cache --build-arg STATIC_ASSETS=1 --pull=true -f Dockerfile -t "${IMAGE}:${IMAGE_TAG}" .
 podman push "${IMAGE}:${IMAGE_TAG}"
 
 if [[ $GIT_BRANCH == "origin/security-compliance" ]]; then


### PR DESCRIPTION
The build is often using cached resources when building which means we don't always get the most up to date packages. Adding no-cache to build_deploy so we can ensure we always build fresh

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
