### PR TITLE
chore(csaf): fix count of files in log

### DIFF
--- a/vmaas/reposcan/redhatcsaf/csaf_controller.py
+++ b/vmaas/reposcan/redhatcsaf/csaf_controller.py
@@ -101,7 +101,7 @@ class CsafController:
             batches.add_item(csaf_file)
 
         self.logger.info("%d CSAF files.", len(csaf_files))
-        self.logger.info("%d CSAF files need to be synced.", len(list(files_to_sync)))
+        self.logger.info("%d CSAF files need to be synced.", batches.get_total_items())
 
         try:
             for i, batch in enumerate(batches, 1):


### PR DESCRIPTION
`files_to_sync` can be generator if we are syncing only out_of_date files, `len(list(files_to_sync))=0` because the `files_to_sync` generator was already iterated when items were added to batches

```
2024-03-26 13:08:54,226:INFO:vmaas.reposcan.redhatcsaf.csaf_controller:0 CSAF files need to be synced.
2024-03-26 13:08:54,226:INFO:vmaas.reposcan.redhatcsaf.csaf_controller:Syncing a batch of 500 CSAF files [1/2]
```
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
