### PR TITLE
feat: list modified packages in modified repos

### DIFF
--- a/vmaas/webapp/webapp.v3.spec.yaml
+++ b/vmaas/webapp/webapp.v3.spec.yaml
@@ -738,6 +738,11 @@ components:
           enum: [ true, false ]
           description: Include content from "third party" repositories into the response, disabled by default.
           default: false
+        show_packages:
+          type: boolean
+          enum: [ true, false ]
+          description: Show updated package names in a repo since the last modified_since
+          default: false
         <<: *req_paging
       required:
         - repository_list
@@ -779,6 +784,11 @@ components:
                     example: cpe:/a:redhat
                 third_party:
                   type: boolean
+                updated_package_names:
+                  type: array
+                  items:
+                    type: string
+                    example: kernel
         last_change:
           type: string
           example: '2020-04-16 20:07:58.500192+00'


### PR DESCRIPTION
RHINENG-9690

endpoint response time with stage data:
- page_size=500 (value used by Patch in vmaas sync), modified_since=2024-01-01T00:00:00Z, 947 repos returned on first page
  - before: 0.059s
  - with show_packages: 0.114s
- page_size=500, modified_since=2000-01-01T00:00:00Z, 1167 repos returned on first page
  - before: 0.056s
  - with show_packages: 1.106s

it is significantly slower, especially if someone wants to use very old date for modified_since but I don't think it is worth optimizing it at the moment, let's see how it performs in openshift and if we see some latency or memory issues

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
