### PR TITLE
fix(build_deploy): only create sc tag when building sc branch

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -23,12 +23,12 @@ export REGISTRY_AUTH_FILE="$AUTH_CONF_DIR/auth.json"
 podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
 podman build --build-arg STATIC_ASSETS=1 --pull=true -f Dockerfile -t "${IMAGE}:${IMAGE_TAG}" .
-podman push "${IMAGE}:${IMAGE_TAG}"
 
 if [[ $GIT_BRANCH == "origin/security-compliance" ]]; then
     podman tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
     podman push "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
 else
+    podman push "${IMAGE}:${IMAGE_TAG}"
     podman tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
     podman push "${IMAGE}:latest"
 fi


### PR DESCRIPTION
## Overview
It has been observed that the `build_deploy` script is set up so that when the SC build Job runs, it write a new image over the original `image_tag` on which the commit is based. 

This update fixes that issue. 


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
