### PR TITLE
fix(csaf): syntax error with IN query

### DIFF
--- a/vmaas/reposcan/database/csaf_store.py
+++ b/vmaas/reposcan/database/csaf_store.py
@@ -61,6 +61,9 @@ class CsafStore(ObjectStore):
             cur.close()
 
     def _save_csaf_files(self, csaf_files: model.CsafFiles) -> None:
+        if not csaf_files:
+            return
+
         cur = self.conn.cursor()
         try:
             files = csaf_files.to_tuples(("name",))
@@ -393,6 +396,10 @@ class CsafStore(ObjectStore):
 
     def store(self, csaf_data: model.CsafData) -> None:
         """Store collection of CSAF files into DB."""
+        if not csaf_data:
+            self.logger.warning("CsafData without cves or files")
+            return
+
         self._save_csaf_files(csaf_data.files)
         self._populate_cves(csaf_data.cves, csaf_data.files)
         self._delete_unreferenced_products()

--- a/vmaas/reposcan/database/test/test_csaf.py
+++ b/vmaas/reposcan/database/test/test_csaf.py
@@ -136,6 +136,15 @@ class TestCsafStore:
         assert res[0] == id_save
         assert res[1] == update_ts
 
+    def test_save_empty_csaf_files(self, csaf_store: CsafStore) -> None:
+        """Test saving empty csaf files."""
+        files = m.CsafFiles()
+        csaf_store._save_csaf_files(files)
+        cur = csaf_store.conn.cursor()
+        cur.execute("SELECT id, name FROM csaf_file WHERE name = 'file'")
+        res = cur.fetchone()
+        assert not res
+
     def test_get_product_attr_id(self, csaf_store: CsafStore) -> None:
         """Test getting product attribute_id."""
         mapping = {"key": 9}

--- a/vmaas/reposcan/redhatcsaf/modeling.py
+++ b/vmaas/reposcan/redhatcsaf/modeling.py
@@ -347,3 +347,6 @@ class CsafData:
 
     files: CsafFiles = field(default_factory=CsafFiles)
     cves: CsafCves = field(default_factory=CsafCves)
+
+    def __bool__(self) -> bool:
+        return bool(self.files) and bool(self.cves)


### PR DESCRIPTION
vmaas-reposcan          | vmaas-reposcan 2024-06-03 17:50:17,781:ERROR:vmaas.reposcan.database.object_store:Failed to import csaf file to DB: 'Traceback (most recent call last):\n  File "/vmaas/vmaas/reposcan/database/csaf_store.py", line 75, in _save_csaf_files\n    cur.execute("select id, name from csaf_file where name in %s", (tuple(files),))\npsycopg2.errors.SyntaxError: syntax error at or near ")"\nLINE 1: select id, name from csaf_file where name in ()\n                                                      ^\n'|

RHINENG-10604

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
