### PR TITLE
fix(webapp): don't show repositories without changed packages

### DIFF
--- a/vmaas/webapp/webapp.v3.spec.yaml
+++ b/vmaas/webapp/webapp.v3.spec.yaml
@@ -743,6 +743,11 @@ components:
           enum: [ true, false ]
           description: Show updated package names in a repo since the last modified_since
           default: false
+        has_packages:
+          type: boolean
+          enum: [ true, false ]
+          description: Return only repositories having advisories with packages released since the last modified_since
+          default: false
         <<: *req_paging
       required:
         - repository_list


### PR DESCRIPTION
repository may be re-generated but no RPM erratum added (push of container images triggers RPM repodata re-generation)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
