### PR TITLE
Sync release graph

### DIFF
--- a/database/upgrade_scripts/030-release_graph.sql
+++ b/database/upgrade_scripts/030-release_graph.sql
@@ -1,0 +1,19 @@
+-- -----------------------------------------------------
+-- Table vmaas.release_graph
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS release_graph (
+  id    SERIAL,
+  name  TEXT UNIQUE NOT NULL, CHECK (NOT empty(name)),
+  graph JSONB NOT NULL,
+  checksum TEXT NOT NULL,
+  PRIMARY KEY (id)
+)TABLESPACE pg_default;
+
+-- -----------------------------------------------------
+-- vmaas users permission setup:
+-- vmaas_writer - has rights to INSERT/UPDATE/DELETE; used by reposcan
+-- vmaas_reader - has SELECT only; used by webapp
+-- -----------------------------------------------------
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.release_graph TO vmaas_writer;
+GRANT USAGE, SELECT, UPDATE ON SEQUENCE public.release_graph_id_seq TO vmaas_writer;
+GRANT SELECT ON TABLE public.release_graph TO vmaas_reader;

--- a/database/vmaas_db_postgresql.sql
+++ b/database/vmaas_db_postgresql.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS db_version (
 )TABLESPACE pg_default;
 
 -- Increment this when editing this file
-INSERT INTO db_version (name, version) VALUES ('schema_version', 29);
+INSERT INTO db_version (name, version) VALUES ('schema_version', 30);
 
 -- -----------------------------------------------------
 -- evr type
@@ -1031,6 +1031,17 @@ CREATE TABLE IF NOT EXISTS operating_system (
   PRIMARY KEY (id),
   CONSTRAINT operating_system_name_major_minor_lifecycle_phase_uq
     UNIQUE (name, major, minor, lifecycle_phase)
+)TABLESPACE pg_default;
+
+-- -----------------------------------------------------
+-- Table vmaas.release_graph
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS release_graph (
+  id    SERIAL,
+  name  TEXT UNIQUE NOT NULL, CHECK (NOT empty(name)),
+  graph JSONB NOT NULL,
+  checksum TEXT NOT NULL,
+  PRIMARY KEY (id)
 )TABLESPACE pg_default;
 
 -- -----------------------------------------------------

--- a/vmaas/reposcan/database/release_graph_store.py
+++ b/vmaas/reposcan/database/release_graph_store.py
@@ -1,0 +1,62 @@
+"""
+Module containing class for fetching/importing RHEL release graph metadata from/into database.
+"""
+
+from psycopg2.extras import execute_values
+
+from vmaas.common.logging_utils import get_logger
+from vmaas.reposcan.database.database_handler import DatabaseHandler
+from vmaas.reposcan.mnm import RELEASE_GRAPH_FAILED_IMPORT
+from vmaas.reposcan.redhatreleasegraph.modeling import ReleaseGraph
+
+
+class ReleaseGraphStore:
+    """Class providing interface for storing release graph metadata."""
+
+    def __init__(self, release_graphs: dict[str, ReleaseGraph]) -> None:
+        self.logger = get_logger(__name__)
+        self.conn = DatabaseHandler.get_connection()
+        self.release_graphs = release_graphs
+
+    def store(self) -> None:
+        """Store release graphs into DB"""
+        cur = self.conn.cursor()
+        graphs_db: dict[str, ReleaseGraph] = {}
+        try:
+            cur.execute("SELECT name, graph, checksum FROM release_graph")
+            for row in cur.fetchall():
+                graphs_db[row[0]] = ReleaseGraph(row[0], row[1], row[2])
+
+            to_insert = []
+            to_update = []
+            for name, graph in self.release_graphs.items():
+                if name not in graphs_db:
+                    to_insert.append((graph.name, graph.graph, graph.checksum))
+                    continue
+                if graphs_db[name].checksum != graph.checksum:
+                    to_update.append((graph.name, graph.graph, graph.checksum))
+
+            if to_insert:
+                execute_values(
+                    cur,
+                    "INSERT INTO release_graph (name, graph, checksum) VALUES %s",
+                    to_insert,
+                )
+            if to_update:
+                execute_values(
+                    cur,
+                    """
+                        UPDATE release_graph AS old
+                        SET graph = new.graph::jsonb, checksum = new.checksum
+                        FROM (VALUES %s) AS new(name, graph, checksum)
+                        WHERE old.name = new.name
+                    """,
+                    to_update,
+                )
+            self.conn.commit()
+        except Exception:  # pylint: disable=broad-except
+            RELEASE_GRAPH_FAILED_IMPORT.inc()
+            self.logger.exception("%s: ", "Failed to import release graph to DB")
+            self.conn.rollback()
+        finally:
+            cur.close()

--- a/vmaas/reposcan/mnm.py
+++ b/vmaas/reposcan/mnm.py
@@ -39,5 +39,6 @@ CSAF_FAILED_IMPORT = Counter('vmaas_reposcan_failed_csaf_import', '# of failed c
 CSAF_FAILED_UPDATE = Counter('vmaas_reposcan_failed_csaf_update', '# of failed csaf-update attempts')
 
 RELEASE_FAILED_IMPORT = Counter('vmaas_reposcan_failed_release_import', '# of failed release-import attempts')
+RELEASE_GRAPH_FAILED_IMPORT = Counter('vmaas_reposcan_failed_release_graph_import', '# of failed release-import attempts')
 
 REPOS_TO_CLEANUP = Gauge('vmaas_reposcan_repos_cleanup', '# of repos to cleanup from DB')

--- a/vmaas/reposcan/redhatreleasegraph/modeling.py
+++ b/vmaas/reposcan/redhatreleasegraph/modeling.py
@@ -1,0 +1,30 @@
+"""
+Module containing models for Release Graph objects.
+"""
+
+import hashlib
+import json
+
+from attr import define, field
+from psycopg2.extras import Json
+
+
+def graph_converter(graph: str | dict) -> Json:
+    """Convert Graph string or dict (json) to psycopg.Json"""
+    if isinstance(graph, dict):
+        return Json(graph)
+    return Json(json.loads(graph))
+
+
+@define
+class ReleaseGraph:
+    """Release graph object."""
+
+    name: str
+    graph: Json = field(converter=graph_converter)
+    checksum: str = field()
+
+    @checksum.default
+    def _checksum_factory(self) -> str:
+        json_str = json.dumps(self.graph.adapted, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(json_str.encode("utf-8")).hexdigest()

--- a/vmaas/reposcan/reposcan.spec.yaml
+++ b/vmaas/reposcan/reposcan.spec.yaml
@@ -200,6 +200,16 @@ paths:
       tags:
         - Sync
 
+  /sync/release_graphs:
+    put:
+      summary: Sync RHEL release graphs metadata
+      operationId: vmaas.reposcan.reposcan.ReleaseGraphSyncHandler.put
+      <<: *secured
+      responses:
+        <<: *sync_responses
+      tags:
+        - Sync
+
   /export/pkgtree:
     put:
       summary: Export package tree


### PR DESCRIPTION
Note: `checksum` is not exported to dump to reduce the dump size since `checksum` won't be used by vmaas-lib
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Add end-to-end support for syncing, exporting, and persisting RHEL release graphs, including new sync handler, exporter updates, data model, DB schema migration, and API documentation

New Features:
- Introduce ReleaseGraphSyncHandler and /sync/release_graphs endpoint to sync RHEL release graph metadata

Enhancements:
- Extend fetch_git to load release graph JSONs and integrate into sync flow
- Add dump and export logic for release_graph in the data exporter and bump dump schema version to 5
- Implement ReleaseGraph model and ReleaseGraphStore to compute checksums and insert/update graphs in the database
- Add environment variables RELEASE_GRAPH_PATH and SYNC_RELEASE_GRAPH and include handler in all_sync_handlers

Build:
- Add release_graph table schema to vmaas_db_postgresql.sql and create migration script 030-release_graph.sql
- Increment database schema version to 30

Documentation:
- Update OpenAPI spec (reposcan.spec.yaml) to document the release_graphs sync endpoint

Chores:
- Introduce RELEASE_GRAPH_FAILED_IMPORT metric counter