### PR TITLE
Process and store RHEL product variants from VEX

### DIFF
--- a/database/upgrade_scripts/031-csaf_product_variant.sql
+++ b/database/upgrade_scripts/031-csaf_product_variant.sql
@@ -1,0 +1,11 @@
+ALTER TABLE csaf_product ADD COLUMN variant_suffix TEXT NOT NULL CHECK (NOT empty(variant_suffix)) DEFAULT 'N/A';
+
+DROP INDEX csaf_product_cpe_id_package_name_id_idx;
+DROP INDEX csaf_product_cpe_id_package_name_id_module_stream_idx;
+DROP INDEX csaf_product_cpe_id_package_name_id_package_id_idx;
+DROP INDEX csaf_product_cpe_id_package_name_id_package_id_module_strea_idx;
+
+CREATE UNIQUE INDEX ON csaf_product(cpe_id, variant_suffix, package_name_id) WHERE package_name_id IS NOT NULL AND package_id IS NULL AND module_stream IS NULL;
+CREATE UNIQUE INDEX ON csaf_product(cpe_id, variant_suffix, package_name_id, module_stream) WHERE package_name_id IS NOT NULL AND package_id IS NULL AND module_stream IS NOT NULL;
+CREATE UNIQUE INDEX ON csaf_product(cpe_id, variant_suffix, package_name_id, package_id) WHERE package_name_id IS NOT NULL and package_id IS NOT NULL AND module_stream IS NULL;
+CREATE UNIQUE INDEX ON csaf_product(cpe_id, variant_suffix, package_name_id, package_id, module_stream) WHERE package_name_id IS NOT NULL and package_id IS NOT NULL AND module_stream IS NOT NULL;

--- a/database/vmaas_db_postgresql.sql
+++ b/database/vmaas_db_postgresql.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS db_version (
 )TABLESPACE pg_default;
 
 -- Increment this when editing this file
-INSERT INTO db_version (name, version) VALUES ('schema_version', 30);
+INSERT INTO db_version (name, version) VALUES ('schema_version', 31);
 
 -- -----------------------------------------------------
 -- evr type
@@ -971,6 +971,7 @@ CREATE TABLE IF NOT EXISTS csaf_product (
   package_name_id   INT NOT NULL,
   package_id        INT NULL,
   module_stream     TEXT NULL CHECK (NOT empty(module_stream)),
+  variant_suffix    TEXT NOT NULL CHECK (NOT empty(variant_suffix)) DEFAULT 'N/A',
   PRIMARY KEY (id),
   CONSTRAINT cpe_id
     FOREIGN KEY (cpe_id)
@@ -983,10 +984,10 @@ CREATE TABLE IF NOT EXISTS csaf_product (
     REFERENCES package (id)
 )TABLESPACE pg_default;
 
-CREATE UNIQUE INDEX ON csaf_product(cpe_id, package_name_id) WHERE package_name_id IS NOT NULL AND package_id IS NULL AND module_stream IS NULL;
-CREATE UNIQUE INDEX ON csaf_product(cpe_id, package_name_id, module_stream) WHERE package_name_id IS NOT NULL AND package_id IS NULL AND module_stream IS NOT NULL;
-CREATE UNIQUE INDEX ON csaf_product(cpe_id, package_name_id, package_id) WHERE package_name_id IS NOT NULL and package_id IS NOT NULL AND module_stream IS NULL;
-CREATE UNIQUE INDEX ON csaf_product(cpe_id, package_name_id, package_id, module_stream) WHERE package_name_id IS NOT NULL and package_id IS NOT NULL AND module_stream IS NOT NULL;
+CREATE UNIQUE INDEX ON csaf_product(cpe_id, variant_suffix, package_name_id) WHERE package_name_id IS NOT NULL AND package_id IS NULL AND module_stream IS NULL;
+CREATE UNIQUE INDEX ON csaf_product(cpe_id, variant_suffix, package_name_id, module_stream) WHERE package_name_id IS NOT NULL AND package_id IS NULL AND module_stream IS NOT NULL;
+CREATE UNIQUE INDEX ON csaf_product(cpe_id, variant_suffix, package_name_id, package_id) WHERE package_name_id IS NOT NULL and package_id IS NOT NULL AND module_stream IS NULL;
+CREATE UNIQUE INDEX ON csaf_product(cpe_id, variant_suffix, package_name_id, package_id, module_stream) WHERE package_name_id IS NOT NULL and package_id IS NOT NULL AND module_stream IS NOT NULL;
 
 -- -----------------------------------------------------
 -- Table vmaas.csaf_cve_product

--- a/vmaas/reposcan/conftest.py
+++ b/vmaas/reposcan/conftest.py
@@ -44,6 +44,7 @@ EXPECTED_CSAF = (
                         3,
                         None,
                         "RHSA-2023:1833",
+                        variant_suffix="8.6.0.Z.EUS",
                     ),
                     csaf_model.CsafProduct(
                         "cpe:/a:redhat:rhel_eus:8.6::appstream",
@@ -51,6 +52,7 @@ EXPECTED_CSAF = (
                         3,
                         "virt:rhel",
                         "RHSA-2023:1833",
+                        variant_suffix="8.6.0.Z.EUS",
                     ),
                 ])
             }

--- a/vmaas/reposcan/redhatcsaf/modeling.py
+++ b/vmaas/reposcan/redhatcsaf/modeling.py
@@ -181,7 +181,7 @@ class CsafProducts:
     """List like collection of CSAF products with lookup by ids."""
 
     _products: list[CsafProduct] = attr.Factory(list)
-    _lookup: dict[tuple[int, int | None, int | None, str | None], CsafProduct] = attr.Factory(dict)
+    _lookup: dict[tuple[int, str, int | None, int | None, str | None], CsafProduct] = attr.Factory(dict)
 
     def to_tuples(
         self,
@@ -224,20 +224,22 @@ class CsafProducts:
             res.append(tuple(items))
         return res
 
-    def get_by_ids_and_module(
+    def get_by_ids_module_variant(
         self,
+        *,
         cpe_id: int,
+        variant_suffix: str,
         package_name_id: int | None,
         package_id: int | None,
         module: str | None,
     ) -> CsafProduct | None:
         """Return product by (cpe_id, package_name_id, package_id, module)."""
-        key = (cpe_id, package_name_id, package_id, module)
+        key = (cpe_id, variant_suffix, package_name_id, package_id, module)
         product = self._lookup.get(key)
         if product is None:
             # not found in _lookup, try to find in _products and add to _lookup
             for prod in self:
-                if (prod.cpe_id, prod.package_name_id, prod.package_id, module) == key:
+                if (prod.cpe_id, prod.variant_suffix, prod.package_name_id, prod.package_id, module) == key:
                     self.add_to_lookup(prod)
                     return prod
         return product
@@ -245,7 +247,7 @@ class CsafProducts:
     def add_to_lookup(self, val: CsafProduct) -> None:
         """Add `val` to internal lookup dict."""
         if val.cpe_id is not None:
-            key = (val.cpe_id, val.package_name_id, val.package_id, val.module)
+            key = (val.cpe_id, val.variant_suffix, val.package_name_id, val.package_id, val.module)
             self._lookup[key] = val
 
     def append(self, val: CsafProduct) -> None:
@@ -256,7 +258,7 @@ class CsafProducts:
     def remove(self, val: CsafProduct) -> None:
         """Remove `val` from CsafProducts."""
         if val.cpe_id is not None:
-            key = (val.cpe_id, val.package_name_id, val.package_id, val.module)
+            key = (val.cpe_id, val.variant_suffix, val.package_name_id, val.package_id, val.module)
             self._lookup.pop(key, None)
         self._products.remove(val)
 

--- a/vmaas/reposcan/redhatcsaf/modeling.py
+++ b/vmaas/reposcan/redhatcsaf/modeling.py
@@ -16,6 +16,9 @@ import attr
 from vmaas.common.date_utils import parse_datetime
 
 
+DEFAULT_VARIANT = "N/A"
+
+
 class CsafProductStatus(IntEnum):
     """CSAF product status enum."""
 
@@ -170,6 +173,7 @@ class CsafProduct:
     cpe_id: int | None = None
     package_name_id: int | None = None
     package_id: int | None = None
+    variant_suffix: str = DEFAULT_VARIANT
 
 
 @attr.s(auto_attribs=True, repr=False)

--- a/vmaas/reposcan/redhatcsaf/test/test_modeling.py
+++ b/vmaas/reposcan/redhatcsaf/test/test_modeling.py
@@ -361,13 +361,25 @@ class TestModels:
         for prod in products:
             if prod.cpe_id:
                 assert prod not in products._lookup.values()
-                res = products.get_by_ids_and_module(prod.cpe_id, prod.package_name_id, prod.package_id, prod.module)
+                res = products.get_by_ids_module_variant(
+                    cpe_id=prod.cpe_id,
+                    variant_suffix=prod.variant_suffix,
+                    package_name_id=prod.package_name_id,
+                    package_id=prod.package_id,
+                    module=prod.module,
+                )
                 assert res == prod
         # get from _lookup (added by previous get_by_ids call)
         for prod in products:
             if prod.cpe_id:
                 assert prod in products._lookup.values()
-                res = products.get_by_ids_and_module(prod.cpe_id, prod.package_name_id, prod.package_id, prod.module)
+                res = products.get_by_ids_module_variant(
+                    cpe_id=prod.cpe_id,
+                    variant_suffix=prod.variant_suffix,
+                    package_name_id=prod.package_name_id,
+                    package_id=prod.package_id,
+                    module=prod.module,
+                )
                 assert res == prod
 
     def test_products_append(self, csaf_products: m.CsafProducts) -> None:


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Add variant suffix handling throughout the CSAF pipeline to support RHEL product variants from VEX, including model, database schema, parsing, storage, lookup, dumping, and tests

New Features:
- Add support for RHEL product variants by introducing a `variant_suffix` field in the CsafProduct model and database schema
- Extend VEX parsing logic to extract and assign variant suffixes for fixed products

Enhancements:
- Update database store logic (split, load, update, insert, dump) and lookup functions to include `variant_suffix` in product tuples and lookups
- Refactor `get_by_ids_and_module` to `get_by_ids_module_variant` to account for variant suffix in lookups

Build:
- Bump database schema version in SQL files and exporter dump schema version

Deployment:
- Add new SQL migration script to add `variant_suffix` column and recreate unique indexes on `csaf_product`

Tests:
- Update unit tests and fixtures to include `variant_suffix` in CsafProducts lookups and conftest data