### PR TITLE
fix(csaf): delete products with trigger

### DIFF
--- a/database/upgrade_scripts/032-csaf_cve_delete_trigger.sql
+++ b/database/upgrade_scripts/032-csaf_cve_delete_trigger.sql
@@ -1,0 +1,18 @@
+create or replace FUNCTION delete_unreferenced_csaf_products()
+  RETURNS TRIGGER AS
+$delete_unreferenced_csaf_products$
+  BEGIN
+    DELETE FROM csaf_product p
+    WHERE p.id = OLD.csaf_product_id
+      AND NOT EXISTS (
+        SELECT 1 FROM csaf_cve_product c
+        WHERE c.csaf_product_id = p.id
+      );
+    RETURN NULL;
+  END;
+$delete_unreferenced_csaf_products$
+  LANGUAGE 'plpgsql';
+
+CREATE TRIGGER csaf_cve_deleted AFTER DELETE ON csaf_cve_product
+  FOR EACH ROW
+  EXECUTE FUNCTION delete_unreferenced_csaf_products();


### PR DESCRIPTION
currently, orphaned products are deleted by iterating over whole csaf_product table after every synced batch

RHINENG-18161

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Implement a database trigger to automatically delete orphaned CSAF products and remove the corresponding manual cleanup code

Enhancements:
- Remove manual unreferenced product deletion in Python
- Add delete_unreferenced_csaf_products function and csaf_cve_deleted trigger
- Bump DB schema version to 32 and include upgrade script