### PR TITLE
fix(csaf): delete orphaned products once after all batches are synced

### DIFF
--- a/vmaas/reposcan/database/csaf_store.py
+++ b/vmaas/reposcan/database/csaf_store.py
@@ -407,7 +407,8 @@ class CsafStore(ObjectStore):
                 self.logger.exception("Failed to populate cve: %s products: %s ", cve, products_copy)
         self.logger.warning("Skipped cves: %s", self.skipped_cve_categories)
 
-    def _delete_unreferenced_products(self) -> None:
+    def delete_unreferenced_products(self) -> None:
+        """Delete orphaned products no longer referenced in csaf_cve_product table."""
         cur = self.conn.cursor()
         try:
             cur.execute(
@@ -440,4 +441,3 @@ class CsafStore(ObjectStore):
 
         self._save_csaf_files(csaf_data.files)
         self._populate_cves(csaf_data.cves, csaf_data.files)
-        self._delete_unreferenced_products()

--- a/vmaas/reposcan/redhatcsaf/csaf_controller.py
+++ b/vmaas/reposcan/redhatcsaf/csaf_controller.py
@@ -133,6 +133,7 @@ class CsafController:
                     to_store.cves.update(parsed_cves)
 
                 self.csaf_store.store(to_store)
+            self.csaf_store.delete_unreferenced_products()
         finally:
             self.clean()
 


### PR DESCRIPTION
RHINENG-18161

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Extract the orphaned product cleanup to run once after all CSAF batches are synced by renaming and exposing the deletion method and moving its invocation to the controller.

Bug Fixes:
- Prevent repeated deletion of orphaned products by moving cleanup from the per-file store call to a single post-sync invocation.

Enhancements:
- Rename `_delete_unreferenced_products` to `delete_unreferenced_products` with a descriptive docstring.