### PR TITLE
reposcan: fetch git repo only once in All-sync and allow to clone URL without token

### DIFF
--- a/vmaas/reposcan/reposcan.py
+++ b/vmaas/reposcan/reposcan.py
@@ -908,6 +908,9 @@ class ReleaseSyncHandler(SyncHandler):
             GitManager.fetch_git()
             releases = GitManager.get_git_releases()
 
+            if releases is None:
+                return "ERROR"
+
             controller = ReleaseController()
             controller.store(releases)
         except Exception as err:  # pylint: disable=broad-except
@@ -950,6 +953,10 @@ class ReleaseGraphSyncHandler(SyncHandler):
 
             GitManager.fetch_git()
             release_graphs = GitManager.get_git_release_graphs()
+
+            if release_graphs is None:
+                return "ERROR"
+
             store = ReleaseGraphStore(release_graphs)
             store.store()
         except Exception as err:  # pylint: disable=broad-except

--- a/vmaas/reposcan/reposcan.py
+++ b/vmaas/reposcan/reposcan.py
@@ -226,7 +226,9 @@ class GitManager:
 
             # Should we just use replacement or add a url handling library, which
             # would be used replace the username in the provided URL ?
-            git_url = REPOLIST_GIT.replace('https://', f'https://{REPOLIST_GIT_TOKEN}:x-oauth-basic@')
+            git_url = REPOLIST_GIT
+            if REPOLIST_GIT_TOKEN:
+                git_url = git_url.replace('https://', f'https://{REPOLIST_GIT_TOKEN}:x-oauth-basic@')
             git_ref = REPOLIST_GIT_REF if REPOLIST_GIT_REF else 'master'
 
             git.Repo.clone_from(git_url, REPOLIST_DIR, branch=git_ref)
@@ -483,9 +485,10 @@ class GitRepoListHandler(RepolistImportHandler):
         if not kwargs.get("child_task", False):
             GitManager.reset_git_dir()
 
-        if not REPOLIST_GIT_TOKEN and not IS_FEDRAMP:
-            LOGGER.warning("REPOLIST_GIT_TOKEN not set, skipping download of repositories from git.")
+        if not any([REPOLIST_GIT, IS_FEDRAMP]):
+            LOGGER.warning("Git repository URL not set and can't use the static repository.")
             return "SKIPPED"
+
         GitManager.fetch_git()
         products, repos = GitManager.get_git_products_repos()
         if products is None or repos is None:
@@ -519,8 +522,8 @@ class GitRepoListCleanupHandler(SyncHandler):
             if not kwargs.get("child_task", False):
                 GitManager.reset_git_dir()
 
-            if not REPOLIST_GIT_TOKEN and not IS_FEDRAMP:
-                LOGGER.warning("REPOLIST_GIT_TOKEN not set, skipping download of repositories from git.")
+            if not any([REPOLIST_GIT, IS_FEDRAMP]):
+                LOGGER.warning("Git repository URL not set and can't use the static repository.")
                 return "SKIPPED"
 
             GitManager.fetch_git()
@@ -897,8 +900,8 @@ class ReleaseSyncHandler(SyncHandler):
             if not kwargs.get("child_task", False):
                 GitManager.reset_git_dir()
 
-            if not REPOLIST_GIT_TOKEN and not IS_FEDRAMP:
-                LOGGER.warning("REPOLIST_GIT_TOKEN not set, skipping download of releases from git.")
+            if not any([REPOLIST_GIT, IS_FEDRAMP]):
+                LOGGER.warning("Git repository URL not set and can't use the static repository.")
                 return "SKIPPED"
 
             GitManager.fetch_git()
@@ -940,8 +943,8 @@ class ReleaseGraphSyncHandler(SyncHandler):
             if not kwargs.get("child_task", False):
                 GitManager.reset_git_dir()
 
-            if not REPOLIST_GIT_TOKEN and not IS_FEDRAMP:
-                LOGGER.warning("REPOLIST_GIT_TOKEN not set, skipping download of release graphs from git.")
+            if not any([REPOLIST_GIT, IS_FEDRAMP]):
+                LOGGER.warning("Git repository URL not set and can't use the static repository.")
                 return "SKIPPED"
 
             GitManager.fetch_git()


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Centralize git repository operations in a new GitManager class, enabling a single clone per sync run, optional tokenless cloning, and streamline parsing of repolist data.

Enhancements:
- Extract git fetching and parsing logic into GitManager with a git_dir cache to avoid redundant clones
- Add reset_git_dir to clear the cached directory before each top-level sync task
- Split parsing of products/repos, releases, and release graphs into dedicated GitManager methods
- Modify clone URL handling to inject REPOLIST_GIT_TOKEN only when provided
- Refactor sync handlers to use GitManager and remove legacy fetch_git implementation