### PR TITLE
fix(reposcan): set CA cert when cvemap is sourced from satellite server

### DIFF
--- a/vmaas/reposcan/katello.py
+++ b/vmaas/reposcan/katello.py
@@ -15,6 +15,10 @@ from vmaas.reposcan.database.repository_store import RepositoryStore
 
 LOGGER = get_logger(__name__)
 
+KATELLO_HOST = os.getenv("KATELLO_HOST", "")  # satellite.example.com
+KATELLO_API_USER = os.getenv("KATELLO_API_USER", "admin")
+KATELLO_API_PASS = os.getenv("KATELLO_API_PASS", "changeme")
+
 KATELLO_CA_CERT_PATH = "/katello-server-ca.crt"
 
 KATELLO_ACCESS_CERT_API = "/katello/api/v2/organizations/%s/download_debug_certificate"

--- a/vmaas/reposcan/reposcan.py
+++ b/vmaas/reposcan/reposcan.py
@@ -35,7 +35,7 @@ from vmaas.reposcan.database.product_store import ProductStore
 from vmaas.reposcan.dbchange import DbChangeAPI
 from vmaas.reposcan.dbdump import DbDumpAPI
 from vmaas.reposcan.exporter import main as export_data, fetch_latest_dump, upload_dump_s3
-from vmaas.reposcan.katello import KatelloApi
+from vmaas.reposcan.katello import KatelloApi, KATELLO_HOST, KATELLO_API_USER, KATELLO_API_PASS
 from vmaas.reposcan.mnm import ADMIN_REQUESTS, FAILED_AUTH, FAILED_IMPORT_CVE, FAILED_IMPORT_CPE, \
     CSAF_FAILED_IMPORT, FAILED_IMPORT_REPO, RELEASE_FAILED_IMPORT, RELEASE_GRAPH_FAILED_IMPORT, REPOS_TO_CLEANUP, \
     REGISTRY
@@ -93,10 +93,6 @@ SYNC_CPE = strtobool(os.getenv("SYNC_CPE", "yes"))
 SYNC_CSAF = strtobool(os.getenv("SYNC_CSAF", "yes"))
 SYNC_RELEASES = strtobool(os.getenv("SYNC_RELEASES", "yes"))
 SYNC_RELEASE_GRAPH = strtobool(os.getenv("SYNC_RELEASE_GRAPH", "yes"))
-
-KATELLO_HOST = os.getenv("KATELLO_HOST", "")  # satellite.example.com
-KATELLO_API_USER = os.getenv("KATELLO_API_USER", "admin")
-KATELLO_API_PASS = os.getenv("KATELLO_API_PASS", "changeme")
 
 
 class TaskStatusResponse(dict):


### PR DESCRIPTION
RHINENG-17238

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Enable use of a custom CA certificate when downloading the CVE map from a Satellite server and centralize Katello configuration.

Bug Fixes:
- Apply the Satellite server’s CA certificate for secure CVE map downloads to prevent TLS validation failures.

Enhancements:
- Add a method to retrieve the CA certificate path when KATELLO_HOST is in use and the file exists
- Pass the retrieved CA certificate to DownloadItem for both head and XML fetches
- Move KATELLO_HOST, KATELLO_API_USER, and KATELLO_API_PASS definitions into the katello module
- Remove redundant Katello environment variable declarations from the reposcan module