### PR TITLE
fix: load missing CSAFProductID2Product map

### DIFF
--- a/vmaas-go/go.mod
+++ b/vmaas-go/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/redhatinsights/app-common-go v1.6.8
 	github.com/redhatinsights/platform-go-middlewares/v2 v2.0.0
-	github.com/redhatinsights/vmaas-lib v1.31.3-0.20250610152327-07980c5900ce
+	github.com/redhatinsights/vmaas-lib v1.31.3
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
 	github.com/zsais/go-gin-prometheus v0.1.0

--- a/vmaas-go/go.sum
+++ b/vmaas-go/go.sum
@@ -92,8 +92,8 @@ github.com/redhatinsights/app-common-go v1.6.8 h1:hyExMp6WHprlGkHKElQvSFF2ZPX8XT
 github.com/redhatinsights/app-common-go v1.6.8/go.mod h1:KW0BK+bnhp3kXU8BFwebQXqCqjdkcRewZsDlXCSNMyo=
 github.com/redhatinsights/platform-go-middlewares/v2 v2.0.0 h1:h/Dj/puWcGxaevSmuFW7IhF0fInlvWjCrxDoS9i3EY4=
 github.com/redhatinsights/platform-go-middlewares/v2 v2.0.0/go.mod h1:W5XsWVaMd+bIjULyCrls2dH4FFPnfxySY1PTzTZl1Dg=
-github.com/redhatinsights/vmaas-lib v1.31.3-0.20250610152327-07980c5900ce h1:JkLWShorjSv4osjCFOqvJXjx1w6MFRIXevxcsCRKS9U=
-github.com/redhatinsights/vmaas-lib v1.31.3-0.20250610152327-07980c5900ce/go.mod h1:3jRU3URLLzBTdBfdN2Dn0eK+sCoAW4MJvD40rD2xKkk=
+github.com/redhatinsights/vmaas-lib v1.31.3 h1:d/46Uz47pKYjVZ70dE8/qJ4CK0WNLXHa3Q9ilICL04c=
+github.com/redhatinsights/vmaas-lib v1.31.3/go.mod h1:3jRU3URLLzBTdBfdN2Dn0eK+sCoAW4MJvD40rD2xKkk=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=


### PR DESCRIPTION
RHINENG-16730

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Update vmaas-lib dependency to include the CSAFProductID2Product map loading fix

Bug Fixes:
- Include missing CSAFProductID2Product map loading by bumping github.com/redhatinsights/vmaas-lib to v1.31.3

Build:
- Bump vmaas-go dependency github.com/redhatinsights/vmaas-lib in go.mod to v1.31.3