### PR TITLE
fix: terminate reposcan gracefully

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ types-pyOpenSSL = "*"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.basedpyright]
+typeCheckingMode = "off"
+
 [tool.mypy]
 disallow_any_generics = true
 disallow_untyped_defs = true


### PR DESCRIPTION
Assisted-By: Cursor

RHINENG-18021

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Implement graceful shutdown for repository scanning tasks by adding cleanup logic, safe termination of worker pool and scheduler on application exit, and removing manual signal handling in favor of uvicorn's built-in shutdown.

Bug Fixes:
- Prevent starting sync tasks when SyncTask is uninitialized
- Handle exceptions during process and worker pool termination

Enhancements:
- Add SyncTask.shutdown to fully terminate worker pool on shutdown
- Register atexit handler to clean up periodic scheduler and sync tasks
- Remove manual OS signal handlers and defer shutdown to uvicorn

Build:
- Disable type checking by adding tool.basedpyright configuration to pyproject.toml