### PR TITLE
fix: resolve vmaas-go docs failure to load

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,8 @@ ADD /vmaas/webapp               /vmaas/vmaas/webapp
 ADD /vmaas/reposcan             /vmaas/vmaas/reposcan
 ADD /vmaas/common               /vmaas/vmaas/common
 
+ADD /vmaas-go/docs/openapi.json     /vmaas/go/src/vmaas/docs/v3/
+
 ADD /vmaas/reposcan/redhatrelease/gen_package_profile.py /usr/local/bin
 
 ADD VERSION /vmaas/

--- a/vmaas-go/docs/docs.go
+++ b/vmaas-go/docs/docs.go
@@ -13,7 +13,7 @@ type openapiData struct {
 
 var appVersions = map[int]openapiData{
 	3: {
-		filepath: "./docs/openapi.json",
+		filepath: "/vmaas/go/src/vmaas/docs/v3/openapi.json",
 		url:      "/api/vmaas/v3/openapi.json",
 	},
 }


### PR DESCRIPTION
copy missing openapi.json into image and fix path

RHINENG-13564

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Copy the missing openapi.json into the Docker image and update its file path in the vmaas-go docs to prevent loading errors

Bug Fixes:
- Add openapi.json to the Docker image to ensure the docs service can load the OpenAPI spec
- Update the docs.go filepath to reference the installed openapi.json location