### PR TITLE
feat: remove proxy from go to python webapp

### DIFF
--- a/vmaas-go/base/utils/gin.go
+++ b/vmaas-go/base/utils/gin.go
@@ -135,8 +135,3 @@ func LogAndRespUnavailable(c *gin.Context, err error) {
 	LogWarn("err", err.Error())
 	respStatusError(c, http.StatusServiceUnavailable, err)
 }
-
-func LogAndRespFailedDependency(c *gin.Context, err error) {
-	LogError("err", err.Error()) // log more descriptive error, possibly showing internal urls
-	respStatusError(c, http.StatusFailedDependency, errors.New("couldn't proxy request to vmaas-webapp-service"))
-}

--- a/vmaas-go/webapp/controllers/cves.go
+++ b/vmaas-go/webapp/controllers/cves.go
@@ -16,7 +16,7 @@ import (
 //	@Produce		json
 //	@Param			cve	path	string	true	"CVE"
 //	@Success		200				{object}	vmaas.Cves
-//	@Failure		400,424,500,503	{object}	utils.ErrorResponse
+//	@Failure		400,500,503	{object}	utils.ErrorResponse
 //	@Router			/cves/{cve} [get]
 func CvesHandler(c *gin.Context) {
 	if !isCacheLoaded(c) {
@@ -41,7 +41,7 @@ func CvesHandler(c *gin.Context) {
 //	@Produce		json
 //	@Param			cve_list	body	vmaas.CvesRequest	true	"cve_list"
 //	@Success		200				{object}	vmaas.Cves
-//	@Failure		400,424,500,503	{object}	utils.ErrorResponse
+//	@Failure		400,500,503	{object}	utils.ErrorResponse
 //	@Router			/cves [post]
 //
 //nolint:lll

--- a/vmaas-go/webapp/controllers/dbchange.go
+++ b/vmaas-go/webapp/controllers/dbchange.go
@@ -13,7 +13,6 @@ import (
 //	@Description	Get last-updated times from VMaaS DB.
 //	@Produce		json
 //	@Success		200	{object}	vmaas.DBChange
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/dbchange [get]
 func DBChangeHandler(c *gin.Context) {

--- a/vmaas-go/webapp/controllers/errata.go
+++ b/vmaas-go/webapp/controllers/errata.go
@@ -17,7 +17,6 @@ import (
 //	@Param			erratum	path	string	true	"erratum"
 //	@Success		200	{object}	vmaas.Errata
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/errata/{erratum} [get]
@@ -47,7 +46,6 @@ func ErrataHandler(c *gin.Context) {
 //	@Param			errata_list	body	vmaas.ErrataRequest	true	"errata_list"
 //	@Success		200	{object}	vmaas.Errata
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/errata [post]

--- a/vmaas-go/webapp/controllers/os.go
+++ b/vmaas-go/webapp/controllers/os.go
@@ -15,7 +15,6 @@ import (
 //	@Produce		json
 //	@Success		200	{object}	vmaas.VulnerabilityReport
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/os/vulnerability/report [get]

--- a/vmaas-go/webapp/controllers/package_names.go
+++ b/vmaas-go/webapp/controllers/package_names.go
@@ -17,7 +17,6 @@ import (
 //	@Param			rpm	path	string	true	"RPM name"
 //	@Success		200	{object}	vmaas.RPMPkgNames
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/package_names/rpms/{rpm} [get]
@@ -45,7 +44,6 @@ func RPMPkgNamesHandler(c *gin.Context) {
 //	@Param			rpm_name_list	body	vmaas.RPMPkgNamesRequest	true	"rpm_name_list"
 //	@Success		200	{object}	vmaas.RPMPkgNames
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/package_names/rpms [post]
@@ -76,7 +74,6 @@ func RPMPkgNamesPostHandler(c *gin.Context) {
 //	@Param			srpm	path	string	true	"SRPM name"
 //	@Success		200	{object}	vmaas.SRPMPkgNames
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/package_names/srpms/{srpm} [get]
@@ -104,7 +101,6 @@ func SRPMPkgNamesHandler(c *gin.Context) {
 //	@Param			srpm_name_list	body	vmaas.SRPMPkgNamesRequest	true	"srpm_name_list"
 //	@Success		200	{object}	vmaas.SRPMPkgNames
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/package_names/srpms [post]

--- a/vmaas-go/webapp/controllers/packages.go
+++ b/vmaas-go/webapp/controllers/packages.go
@@ -17,7 +17,6 @@ import (
 //	@Param			nevra	path	string	true	"NEVRA"
 //	@Success		200	{object}	vmaas.Packages
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/packages/{nevra} [get]
@@ -45,7 +44,6 @@ func PackagesHandler(c *gin.Context) {
 //	@Param			package_list	body	vmaas.PackagesRequest	true	"package_list"
 //	@Success		200	{object}	vmaas.Packages
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/packages [post]

--- a/vmaas-go/webapp/controllers/patches.go
+++ b/vmaas-go/webapp/controllers/patches.go
@@ -17,7 +17,6 @@ import (
 //	@Param			nevra	path	string	true	"NEVRA"
 //	@Success		200	{object}	vmaas.Patches
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/patches/{nevra} [get]
@@ -45,7 +44,6 @@ func PatchesHandler(c *gin.Context) {
 //	@Param			package_list	body	vmaas.Request	true	"package_list"
 //	@Success		200	{object}	vmaas.Patches
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/patches [post]

--- a/vmaas-go/webapp/controllers/pkglist.go
+++ b/vmaas-go/webapp/controllers/pkglist.go
@@ -17,7 +17,6 @@ import (
 //	@Produce		json
 //	@Success		200	{object}	vmaas.PkgList
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/pkglist [post]
 func PkgListPostHandler(c *gin.Context) {

--- a/vmaas-go/webapp/controllers/pkgtree.go
+++ b/vmaas-go/webapp/controllers/pkgtree.go
@@ -17,7 +17,6 @@ import (
 //	@Param			package_name	path	string	true	"package name"
 //	@Success		200	{object}	vmaas.PkgTree
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/pkgtree/{package_name} [get]
@@ -47,7 +46,6 @@ func PkgTreeHandler(c *gin.Context) {
 //	@Param			package_name_list	body	vmaas.PkgTreeRequest	true	"package_name_list"
 //	@Success		200	{object}	vmaas.PkgTree
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/pkgtree [post]

--- a/vmaas-go/webapp/controllers/repos.go
+++ b/vmaas-go/webapp/controllers/repos.go
@@ -18,7 +18,6 @@ import (
 //	@Param			repo	path	string	true	"repository"
 //	@Success		200	{object}	vmaas.Repos
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/repos/{repo} [get]
@@ -46,7 +45,6 @@ func ReposHandler(c *gin.Context) {
 //	@Param			repository_list	body	vmaas.ReposRequest	true	"repository_list"
 //	@Success		200	{object}	vmaas.Repos
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/repos [post]

--- a/vmaas-go/webapp/controllers/updates.go
+++ b/vmaas-go/webapp/controllers/updates.go
@@ -17,7 +17,6 @@ import (
 //	@Param			package	path	string	true	"NEVRA"
 //	@Success		200	{object}	vmaas.Updates
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/updates/{package} [get]
@@ -45,7 +44,6 @@ func UpdatesHandler(c *gin.Context) {
 //	@Param			package_list	body	vmaas.Request	true	"package_list"
 //	@Success		200	{object}	vmaas.Updates
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/updates [post]

--- a/vmaas-go/webapp/controllers/version.go
+++ b/vmaas-go/webapp/controllers/version.go
@@ -13,7 +13,6 @@ import (
 //	@Description	Get VMaaS version.
 //	@Produce		json
 //	@Success		200	{string}	string
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/version [get]
 func VersionHandler(c *gin.Context) {

--- a/vmaas-go/webapp/controllers/vulnerabilities.go
+++ b/vmaas-go/webapp/controllers/vulnerabilities.go
@@ -17,7 +17,6 @@ import (
 //	@Param			package	path	string	true	"NEVRA"
 //	@Success		200	{object}	vmaas.Vulnerabilities
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/vulnerabilities/{package} [get]
@@ -46,7 +45,6 @@ func VulnerabilitiesHandler(c *gin.Context) {
 //	@Success		200	{object}	vmaas.Vulnerabilities
 //	@Success		200	{object}	vmaas.VulnerabilitiesExtended	"if request.extended"
 //	@Failure		400	{object}	utils.ErrorResponse
-//	@Failure		424	{object}	utils.ErrorResponse
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Failure		503	{object}	utils.ErrorResponse
 //	@Router			/vulnerabilities [post]


### PR DESCRIPTION
RHINENG-13566

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Remove the fallback proxy to the Python webapp, eliminate associated error handling functions, and update Swagger annotations to drop the 424 status code.

Enhancements:
- Remove NoRoute proxy registration and delete the vmaasProxy handler.
- Delete the LogAndRespFailedDependency utility function.

Documentation:
- Remove 424 Failed Dependency responses from Swagger annotations in all controllers.