### PR TITLE
fix: assume DEFAULT when unknown org is requested

### DIFF
--- a/vmaas-go/go.mod
+++ b/vmaas-go/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/redhatinsights/app-common-go v1.6.8
 	github.com/redhatinsights/platform-go-middlewares/v2 v2.0.0
-	github.com/redhatinsights/vmaas-lib v1.31.3
+	github.com/redhatinsights/vmaas-lib v1.31.4
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/files v1.0.1

--- a/vmaas-go/go.sum
+++ b/vmaas-go/go.sum
@@ -105,8 +105,8 @@ github.com/redhatinsights/app-common-go v1.6.8 h1:hyExMp6WHprlGkHKElQvSFF2ZPX8XT
 github.com/redhatinsights/app-common-go v1.6.8/go.mod h1:KW0BK+bnhp3kXU8BFwebQXqCqjdkcRewZsDlXCSNMyo=
 github.com/redhatinsights/platform-go-middlewares/v2 v2.0.0 h1:h/Dj/puWcGxaevSmuFW7IhF0fInlvWjCrxDoS9i3EY4=
 github.com/redhatinsights/platform-go-middlewares/v2 v2.0.0/go.mod h1:W5XsWVaMd+bIjULyCrls2dH4FFPnfxySY1PTzTZl1Dg=
-github.com/redhatinsights/vmaas-lib v1.31.3 h1:d/46Uz47pKYjVZ70dE8/qJ4CK0WNLXHa3Q9ilICL04c=
-github.com/redhatinsights/vmaas-lib v1.31.3/go.mod h1:3jRU3URLLzBTdBfdN2Dn0eK+sCoAW4MJvD40rD2xKkk=
+github.com/redhatinsights/vmaas-lib v1.31.4 h1:gOi0F2Qy7siLthtvfX7uHmMs3E58cmYpP/b8Xx1nQFQ=
+github.com/redhatinsights/vmaas-lib v1.31.4/go.mod h1:c8mQPIX/aEVYpoi7puMLun7ITkXJ7J6ROo++N012asY=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Update the vmaas-lib dependency to v1.31.4 to include the fix that defaults to "DEFAULT" when an unknown organization is requested.

Bug Fixes:
- Bump vmaas-lib to v1.31.4 to apply the fallback-to-DEFAULT behavior for unknown org requests.

Chores:
- Update go.mod and go.sum to reflect the dependency version bump.