### PR TITLE
fix: respond on legacy api paths

### DIFF
--- a/vmaas-go/docs/docs.go
+++ b/vmaas-go/docs/docs.go
@@ -14,11 +14,11 @@ type openapiData struct {
 var appVersions = map[int]openapiData{
 	3: {
 		filepath: "/vmaas/go/src/vmaas/docs/v3/openapi.json",
-		url:      "/api/vmaas/v3/openapi.json",
+		url:      "/openapi.json",
 	},
 }
 
-func Init(app *gin.Engine) string {
+func Init(app *gin.RouterGroup) string {
 	maxVer := 1
 	for ver, data := range appVersions {
 		if ver > maxVer {

--- a/vmaas-go/webapp/middlewares/swagger.go
+++ b/vmaas-go/webapp/middlewares/swagger.go
@@ -8,9 +8,10 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
-func SetSwagger(app *gin.Engine) {
+func SetSwagger(app *gin.RouterGroup) {
 	// Serving openapi docs
 	openapiURL := docs.Init(app)
-	url := ginSwagger.URL(openapiURL)
-	app.GET("/api/vmaas/v3/ui/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, url))
+	basepath := app.BasePath()
+	url := ginSwagger.URL(basepath + openapiURL)
+	app.GET("/ui/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, url))
 }

--- a/vmaas-go/webapp/webapp.go
+++ b/vmaas-go/webapp/webapp.go
@@ -14,7 +14,7 @@ import (
 	_ "net/http/pprof" //nolint:gosec
 )
 
-var basepaths = []string{"/api/v3", "/api/vmaas/v3"}
+var basepaths = []string{"/api/v1", "/api/vmaas/v1", "/api/v2", "/api/vmaas/v2", "/api/v3", "/api/vmaas/v3"}
 
 //	@title			VMaaS webapp API
 //	@version		{{.Version}}
@@ -40,13 +40,13 @@ func Run() {
 	app.Use(middlewares.Recovery())
 	app.Use(middlewares.RequestResponseLogger())
 	middlewares.Prometheus().Use(app)
-	middlewares.SetSwagger(app)
 	app.HandleMethodNotAllowed = true
 
 	// routes
 	core.InitProbes(app)
 	for _, path := range basepaths {
 		api := app.Group(path)
+		middlewares.SetSwagger(api)
 		routes.InitAPI(api)
 	}
 


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Serve Swagger UI and OpenAPI docs under all API versions (including legacy v1/v2) by refactoring the middleware to use router groups and derive URLs dynamically

Enhancements:
- Expand supported API base paths to include /api/v1, /api/vmaas/v1, /api/v2, and /api/vmaas/v2
- Refactor SetSwagger and docs.Init to accept a RouterGroup and compute the OpenAPI JSON URL relative to the group's base path
- Mount the Swagger UI at "/ui/*any" under each versioned group instead of a hardcoded path