### PR TITLE
chore: don't mention copr repo in dockerfile

### DIFF
--- a/.github/workflows/container-publish.yaml
+++ b/.github/workflows/container-publish.yaml
@@ -16,6 +16,7 @@ env:
   REGISTRY: quay.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: "iop/vmaas"
+  ALT_REPO: "https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo"
 
 
 jobs:
@@ -86,6 +87,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            ALT_REPO=${{ env.ALT_REPO }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 ARG BUILDIMG=registry.access.redhat.com/ubi9/ubi-minimal
 ARG RUNIMG=registry.access.redhat.com/ubi9/ubi-minimal
-ARG COPR_REPO=https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo
+ARG ALT_REPO
 
 FROM ${BUILDIMG} AS buildimg
 
-ARG COPR_REPO
-RUN (microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo $COPR_REPO) && \
+ARG ALT_REPO
+RUN (microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo $ALT_REPO) && \
     microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
         go-toolset rpm-devel && \
     microdnf clean all
@@ -22,10 +22,10 @@ WORKDIR /vmaas
 # runtime image
 FROM ${RUNIMG} AS runtimeimg
 
-ARG COPR_REPO
+ARG ALT_REPO
 ARG VAR_RPMS=""
 
-RUN (microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo $COPR_REPO) && \
+RUN (microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo $ALT_REPO) && \
     microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
         python312 python3.12-pip python3-rpm python3-dnf which nginx git-core shadow-utils diffutils systemd libicu postgresql \
         $VAR_RPMS && \

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,6 +17,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
+        ALT_REPO: "https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo"
         VAR_RPMS: "findutils"
         VAR_POETRY_INSTALL_OPT: "--with dev"
         REQUIRE_RHEL: "no"
@@ -55,6 +56,7 @@ services:
       dockerfile: Dockerfile
       args:
         REQUIRE_RHEL: "no"
+        ALT_REPO: "https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo"
       target: buildimg
     image: vmaas/test-go:latest
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       dockerfile: ./Dockerfile
       args:
         REQUIRE_RHEL: "no"
+        ALT_REPO: "https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo"
     image: vmaas/app:latest
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
add copr repo with build arg
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Parameterize the Postgres repository URL via a new ALT_REPO build argument, removing the hardcoded COPR_REPO from the Dockerfile and injecting the default URL through CI and compose configurations.

New Features:
- Introduce ALT_REPO build argument for specifying an alternative Postgres repository at build time.

Enhancements:
- Replace hardcoded COPR_REPO references with ALT_REPO in the Dockerfile for both build and runtime stages.

CI:
- Pass ALT_REPO as a build-arg in the container-publish GitHub Actions workflow.

Chores:
- Add ALT_REPO argument and default URL to docker-compose.yml and docker-compose.test.yml configurations.