### PR TITLE
fix(reposcan): use module information from suffix also for known_affected type

### DIFF
--- a/vmaas/reposcan/redhatcsaf/csaf_controller.py
+++ b/vmaas/reposcan/redhatcsaf/csaf_controller.py
@@ -252,6 +252,8 @@ class CsafController:
                         # such as container (rhel-8/python-eventlet) or a java package (com.google.guava/guava)
                         # meaning it is not an rpm and we don't want to process this product
                         raise ComponentError(f"Not RPM component '{product}'")
+                elif module_from_suffix:
+                    module = module_from_suffix
             case "fixed":
                 splitted_product = branch_product.split("-", 1)
                 if len(splitted_product) != 2:


### PR DESCRIPTION
previously support of unfixed CVE modules was limited

RHINENG-24644

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Fix handling of unfixed CVE modules by applying suffix-derived module information for known-affected products that lack explicit module data.