### PR TITLE
chore: bump konflux-pipelines to v1.67.0

### DIFF
--- a/.tekton/vmaas-pull-request.yaml
+++ b/.tekton/vmaas-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "master" || target_branch == "hotfix")
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.66.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.67.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: insights-vulnerability

--- a/.tekton/vmaas-push.yaml
+++ b/.tekton/vmaas-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && (target_branch == "master" || target_branch == "hotfix")
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.66.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.67.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: insights-vulnerability

--- a/.tekton/vmaas-sc-pull-request.yaml
+++ b/.tekton/vmaas-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.66.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.67.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-vulnerability-sc

--- a/.tekton/vmaas-sc-push.yaml
+++ b/.tekton/vmaas-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.66.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.67.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-vulnerability-sc


### PR DESCRIPTION
## Summary

Bumps `konflux-pipelines` pipeline reference to `v1.67.0` in all `.tekton/` pipeline annotations.

## Why

Three Satellite 6.19 release pipeline runs (yuptoo, vmaas, ingress) failed because the prior pipeline version breaks the conforma validation path. v1.67.0 restores it.

## Changes

- `pipelinesascode.tekton.dev/pipeline` annotation updated in all `.tekton/*.yaml` files (4 files: `vmaas-pull-request.yaml`, `vmaas-push.yaml`, `vmaas-sc-pull-request.yaml`, `vmaas-sc-push.yaml`)

## Testing

PipelinesAsCode picks up the updated annotation automatically on the next push/PR to this branch.

## Summary by Sourcery

CI:
- Bump konflux-pipelines reference from v1.66.0 to v1.67.0 in all vmaas Tekton pipeline annotations.