### PR TITLE
ci: set minimum age of 3 days for go and py deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,12 +42,14 @@
     {
       "matchManagers": ["poetry"],
       "groupName": "poetry dependencies",
-      "groupSlug": "poetry-deps"
+      "groupSlug": "poetry-deps",
+      "minimumReleaseAge": "3 days"
     },
     {
       "matchCategories": ["golang"],
       "groupName": "go modules",
-      "groupSlug": "go-modules"
+      "groupSlug": "go-modules",
+      "minimumReleaseAge": "3 days"
     },
     {
       "matchCategories": ["docker"],


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

CI:
- Adjust Renovate configuration to delay Go and Python dependency updates until they are at least three days old.