### PR TITLE
update go.mod to match rpm lock

### DIFF
--- a/vmaas-go/go.mod
+++ b/vmaas-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/vmaas
 
-go 1.24.4
+go 1.25.9
 
 require (
 	github.com/aws/aws-sdk-go v1.55.7


### PR DESCRIPTION
chore: bump go toolchain version to 1.25.9

# OVERVIEW
* Update the module’s Go version requirement from 1.24.4 to 1.25.9 in go.mod.
* match rpm lock version
* Introduces a 30-second timeout context for HTTP server shutdown to ensure graceful termination.
      to remediate gosec fail: Error: /home/runner/work/vmaas/vmaas/vmaas-go/base/utils/gin.go:83:2: G118: Goroutine uses context.Background/TODO while request-scoped context is available (gosec)

Fixes: RHINENG-26509

## Summary by Sourcery

Build:
- Bump the Go version in go.mod from 1.24.4 to 1.25.9 to match the locked RPM toolchain version.