### PR TITLE
ci(renovate): set pkg rules on master only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,18 +41,21 @@
     },
     {
       "matchManagers": ["poetry"],
+      "matchBaseBranches": ["master"],
       "groupName": "poetry dependencies",
       "groupSlug": "poetry-deps",
       "minimumReleaseAge": "3 days"
     },
     {
       "matchCategories": ["golang"],
+      "matchBaseBranches": ["master"],
       "groupName": "go modules",
       "groupSlug": "go-modules",
       "minimumReleaseAge": "3 days"
     },
     {
       "matchCategories": ["docker"],
+      "matchBaseBranches": ["master"],
       "groupName": "docker and rpm references",
       "groupSlug": "docker-rpm-refs",
       "pinDigests": true,
@@ -63,6 +66,7 @@
     },
     {
       "matchCategories": ["ci"],
+      "matchBaseBranches": ["master"],
       "groupName": "ci references",
       "groupSlug": "ci-refs",
       "pinDigests": true


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Build:
- Update Renovate configuration so package rules only apply on the main release branch.