### PR TITLE
chore: repos cleanup

### DIFF
--- a/vmaas/reposcan/cleanup_placeholder_repos.py
+++ b/vmaas/reposcan/cleanup_placeholder_repos.py
@@ -12,22 +12,25 @@ from vmaas.reposcan.database.repository_store import RepositoryStore
 
 LOGGER = get_logger(__name__)
 
+# Only never-synced repos (revision IS NULL, as a safety condition)
 UNRESOLVED_PLACEHOLDER_REPOS_SQL = """select cs.label, a.name, r.releasever, o.name, r.url
                                       from repo r
                                       join content_set cs on cs.id = r.content_set_id
                                       join organization o on o.id = r.org_id
                                       left join arch a on a.id = r.basearch_id
                                       where (r.url like %s or r.url like %s)
-                                      and r.revision is null""" # is null just safety condition 
+                                      and r.revision is null"""
 
 
 def find_placeholder_repos(conn):
+    """Return never-synced repos whose URL still contains placeholders"""
     with conn.cursor() as cur:
         cur.execute(UNRESOLVED_PLACEHOLDER_REPOS_SQL, ('%$releasever%', '%$basearch%'))
         return cur.fetchall()
 
 
 def main():
+    """CLI entry point for placeholder repository cleanup"""
     parser = argparse.ArgumentParser(
         description="Delete never-synced repos whose URL still contains $releasever or $basearch"
     )

--- a/vmaas/reposcan/cleanup_placeholder_repos.py
+++ b/vmaas/reposcan/cleanup_placeholder_repos.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Cleanup repository rows whose URL still contains $releasever or $basearch placeholders
+and were never synced (revision IS NULL, just as a safety check but repos should match)
+"""
+import argparse
+import sys
+
+from vmaas.common.logging_utils import get_logger, init_logging
+from vmaas.reposcan.database.database_handler import DatabaseHandler, init_db
+from vmaas.reposcan.database.repository_store import RepositoryStore
+
+LOGGER = get_logger(__name__)
+
+UNRESOLVED_PLACEHOLDER_REPOS_SQL = """select cs.label, a.name, r.releasever, o.name, r.url
+                                      from repo r
+                                      join content_set cs on cs.id = r.content_set_id
+                                      join organization o on o.id = r.org_id
+                                      left join arch a on a.id = r.basearch_id
+                                      where (r.url like %s or r.url like %s)
+                                      and r.revision is null""" # is null just safety condition 
+
+
+def find_placeholder_repos(conn):
+    with conn.cursor() as cur:
+        cur.execute(UNRESOLVED_PLACEHOLDER_REPOS_SQL, ('%$releasever%', '%$basearch%'))
+        return cur.fetchall()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Delete never-synced repos whose URL still contains $releasever or $basearch"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List repositories that would be deleted without modifying the database",
+    )
+    args = parser.parse_args()
+
+    init_logging()
+    init_db()
+    conn = DatabaseHandler.get_connection()
+    try:
+        repos = find_placeholder_repos(conn)
+        if not repos:
+            LOGGER.info("No unresolved placeholder repositories found. No changes were made.")
+            return 0
+
+        for content_set, basearch, releasever, organization, url in repos:
+            LOGGER.info(
+                "Unresolved placeholder repository: %s (%s)",
+                ", ".join(filter(None, (content_set, basearch, releasever, organization))),
+                url,
+            )
+
+        if args.dry_run:
+            LOGGER.info("Dry run: %d repositories will be deleted", len(repos))
+            return 0
+
+        repo_store = RepositoryStore()
+        for content_set, basearch, releasever, organization, _url in repos:
+            # Delete using content_set likely to be safe, vmaas_db_postgresql.sql Lines 477-480
+            repo_store.delete_content_set(
+                content_set, basearch=basearch, releasever=releasever, organization=organization,
+            )
+        # cleans orphaned packages and errata left behind after repo deletion
+        repo_store.cleanup_unused_data()
+        LOGGER.info("Removed %d unresolved placeholder repositories", len(repos))
+    except Exception:  # pylint: disable=broad-except
+        LOGGER.exception("Placeholder repository cleanup failed")
+        DatabaseHandler.rollback()
+        return 1
+    finally:
+        DatabaseHandler.close_connection()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vmaas/reposcan/reposcan.py
+++ b/vmaas/reposcan/reposcan.py
@@ -419,6 +419,13 @@ class RepolistImportHandler(SyncHandler):
                 for content_set_label, content_set in product["content_sets"].items():
                     products[product_name]["content_sets"][content_set_label] = content_set
                     for repo_url, basearch, releasever in cls._content_set_to_repos(content_set):
+                        if "$releasever" in repo_url or "$basearch" in repo_url:
+                            LOGGER.info(
+                                "Skipping %s: unresolved URL placeholders in %s",
+                                content_set_label, repo_url,
+                            )
+                            # ... skip importing repositories, that have placeholders but not placeholders resolved as concrete releasever and basearch
+                            continue
                         repos.append((repo_url, content_set_label, basearch, releasever,
                                       cert_name, ca_cert, cert, key, organization))
 


### PR DESCRIPTION
Single run script for cleanup repositories with unresolved placeholder previously synced by vmaas RHINENG-3320.
First run the script using **--dry-run**. As of today, on the prod, there should be 
155 (templates with resolved siblings) +
12 (templates with no resolved siblings), 
so total of **167** placeholder only records to be cleaned up.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Skip importing repositories with unresolved URL placeholders and add a script to clean up existing unresolved placeholder repositories from the database.

Bug Fixes:
- Avoid importing repositories whose URLs still contain unresolved $releasever or $basearch placeholders.

Enhancements:
- Introduce a one-off cleanup script that identifies and deletes never-synced repositories with unresolved URL placeholders, including post-cleanup of unused data.