### PR TITLE
chore : add single repo sync for Satellite

### DIFF
--- a/conf/reposcan.env
+++ b/conf/reposcan.env
@@ -43,6 +43,9 @@ CSAF_VEX_SIGNATURE_VERIFY=true
 # Set to "false" for IoP where changes.csv is unavailable.
 CSAF_VEX_INDEX_CSV_ENABLED=true
 
+# Interval in minutes for processing per-repo sync queue from Satellite (IoP mode). 0 = disabled.
+REPO_SYNC_QUEUE_INTERVAL_MINUTES=5
+
 PG_MAX_STACK_DEPTH=6144
 
 ALLOWED_LONG_TERM_RELEASES=eus,aus

--- a/conf/reposcan.env
+++ b/conf/reposcan.env
@@ -43,6 +43,9 @@ CSAF_VEX_SIGNATURE_VERIFY=true
 # Set to "false" for IoP where changes.csv is unavailable.
 CSAF_VEX_INDEX_CSV_ENABLED=true
 
+# Interval in minutes for processing per-repo sync queue. 0 = disabled.
+REPO_SYNC_QUEUE_INTERVAL_MINUTES=5
+
 PG_MAX_STACK_DEPTH=6144
 
 ALLOWED_LONG_TERM_RELEASES=eus,aus

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -200,6 +200,8 @@ objects:
           value: ${CSAF_VEX_SIGNATURE_VERIFY}
         - name: CSAF_VEX_INDEX_CSV_ENABLED
           value: ${CSAF_VEX_INDEX_CSV_ENABLED}
+        - name: REPO_SYNC_QUEUE_INTERVAL_MINUTES
+          value: ${REPO_SYNC_QUEUE_INTERVAL_MINUTES}
         - name: CSAF_PRODUCT_STATUS_LIST
           value: ${CSAF_PRODUCT_STATUS_LIST}
         - name: ENABLE_PROFILER
@@ -405,6 +407,8 @@ parameters:
   value: "true"
 - name: CSAF_VEX_INDEX_CSV_ENABLED
   value: "true"
+- name: REPO_SYNC_QUEUE_INTERVAL_MINUTES
+  value: "5"
 - name: PG_MAX_STACK_DEPTH
   value: ''
 - name: CSAF_PRODUCT_STATUS_LIST

--- a/vmaas/reposcan/reposcan.py
+++ b/vmaas/reposcan/reposcan.py
@@ -10,6 +10,7 @@ import json
 import os
 import shutil
 import signal
+import threading
 from multiprocessing.pool import Pool
 import multiprocessing
 from enum import StrEnum
@@ -97,6 +98,13 @@ SYNC_CPE = strtobool(os.getenv("SYNC_CPE", "yes"))
 SYNC_CSAF = strtobool(os.getenv("SYNC_CSAF", "yes"))
 SYNC_RELEASES = strtobool(os.getenv("SYNC_RELEASES", "yes"))
 SYNC_RELEASE_GRAPH = strtobool(os.getenv("SYNC_RELEASE_GRAPH", "yes"))
+REPO_SYNC_QUEUE_INTERVAL_MINUTES = int(os.getenv("REPO_SYNC_QUEUE_INTERVAL_MINUTES", "5"))
+
+# Queue for per-repo sync requests.
+# Stores tuples of (label, releasever_or_None, basearch_or_None).
+# Protected by a lock because BackgroundScheduler and HTTP workers access it concurrently.
+_repo_queue: set[tuple[str, str | None, str | None, str]] = set()
+_repo_queue_lock = threading.Lock()
 
 
 class TaskStatusResponse(dict):
@@ -738,6 +746,17 @@ class DbChangeHandler():
         return result
 
 
+def _queue_repos(repos: list[dict]) -> str:
+    """Add repositories to the sync queue. Deduplication is handled by set uniqueness."""
+    for repo in repos:
+        label = repo["label"]
+        releasever = repo.get("releasever") or None
+        basearch = repo.get("basearch") or None
+        organization = repo.get("organization") or DEFAULT_ORG_NAME
+        _repo_queue.add((label, releasever, basearch, organization))
+    return "Queued %d repo(s). Queue size: %d." % (len(repos), len(_repo_queue))
+
+
 class RepoSyncHandler(SyncHandler):
     """Handler for repository sync API."""
 
@@ -746,7 +765,6 @@ class RepoSyncHandler(SyncHandler):
     @classmethod
     def put(cls, **kwargs):
         """Sync repositories stored in DB."""
-
         status_code, status_msg = cls.start_task()
         return status_msg, status_code
 
@@ -759,6 +777,65 @@ class RepoSyncHandler(SyncHandler):
             repository_controller = RepositoryController()
             repository_controller.add_db_repositories()
             repository_controller.store()
+        except Exception as err:  # pylint: disable=broad-except
+            msg = "Internal server error <%s>" % hash(err)
+            LOGGER.exception(msg)
+            DatabaseHandler.rollback()
+            if isinstance(err, DatabaseError):
+                return "DB_ERROR"
+            return "ERROR"
+        finally:
+            DatabaseHandler.close_connection()
+        return "OK"
+
+
+class RepoQueueHandler:
+    """Handler for queuing specific repositories for sync."""
+
+    @staticmethod
+    def post(body, **kwargs):
+        """Queue repositories for sync. Accepts a JSON list of repo objects."""
+        with _repo_queue_lock:
+            msg = _queue_repos(body)
+        LOGGER.info(msg)
+        return TaskStartResponse(msg), 200
+
+
+class RepoQueueSyncHandler(SyncHandler):
+    """Handler for syncing only repositories queued via per-repo sync requests."""
+
+    task_type = "Sync queued repositories"
+
+    @staticmethod
+    def run_task(*args, **kwargs):
+        """Sync only repositories that were queued."""
+        queue: set[tuple[str, str | None, str | None, str]] = kwargs.get("queue", set())
+        try:
+            init_logging()
+            init_db()
+            controller = RepositoryController()
+            repos = controller.repo_store.list_repositories()
+            for (content_set, basearch, releasever, organization), repo_dict in repos.items():
+                for (q_label, q_releasever, q_basearch, q_org) in queue:
+                    if content_set != q_label:
+                        continue
+                    if q_releasever is not None and releasever != q_releasever:
+                        continue
+                    if q_basearch is not None and basearch != q_basearch:
+                        continue
+                    if organization != q_org:
+                        continue
+                    controller.repo_store.content_set_to_db_id[content_set] = repo_dict["content_set_id"]
+                    controller.add_repository(
+                        repo_dict["url"], content_set, basearch, releasever, organization,
+                        cert_name=repo_dict["cert_name"], ca_cert=repo_dict["ca_cert"],
+                        cert=repo_dict["cert"], key=repo_dict["key"],
+                    )
+                    break
+            if controller.repositories:
+                controller.store()
+            else:
+                LOGGER.info("No repositories found in DB for queue entries: %s, skipping sync.", queue)
         except Exception as err:  # pylint: disable=broad-except
             msg = "Internal server error <%s>" % hash(err)
             LOGGER.exception(msg)
@@ -1181,7 +1258,23 @@ def periodic_sync():
     AllSyncHandler.start_task()
 
 
-def create_app(specs):
+def sync_queued_repos():
+    """Process per-repo sync requests queued."""
+    if SyncTask.is_running():
+        LOGGER.info("Repo queue sync skipped: another task already in progress. Queue size: %d", len(_repo_queue))
+        return
+
+    with _repo_queue_lock:
+        if not _repo_queue:
+            return
+        queue = _repo_queue.copy()
+        _repo_queue.clear()
+
+    LOGGER.info("Processing %d queued repository entries: %s", len(queue), queue)
+    RepoQueueSyncHandler.start_task(queue=queue)
+
+
+def create_app(specs):  # pylint: disable=too-many-branches,too-many-statements
     """Create reposcan app."""
     init_logging()
     SyncTask.init()
@@ -1193,7 +1286,7 @@ def create_app(specs):
     metrics_refresh_interval = int(os.getenv('METRICS_GAUGE_REFRESH_INTERVAL_MINUTES', "240"))
 
     # Sync jobs to run
-    periodic_job_intervals = (sync_interval, metrics_refresh_interval)
+    periodic_job_intervals = (sync_interval, metrics_refresh_interval, REPO_SYNC_QUEUE_INTERVAL_MINUTES)
 
     sched = None
     if any(job > 0 for job in periodic_job_intervals):
@@ -1216,6 +1309,12 @@ def create_app(specs):
             LOGGER.warning("REPOSCAN_SYNC_INTERVAL_MINUTES is 0 - Certification metrics gauge may not show actual data.")
     else:
         LOGGER.info("Periodic metrics gauge disabled.")
+
+    if REPO_SYNC_QUEUE_INTERVAL_MINUTES > 0:
+        sched.add_job(sync_queued_repos, trigger="interval", minutes=REPO_SYNC_QUEUE_INTERVAL_MINUTES)
+        LOGGER.info("Repo queue sync running every %s minute(s).", REPO_SYNC_QUEUE_INTERVAL_MINUTES)
+    else:
+        LOGGER.info("Repo queue sync disabled.")
 
     if sched is not None:
         sched.start()

--- a/vmaas/reposcan/reposcan.py
+++ b/vmaas/reposcan/reposcan.py
@@ -10,6 +10,7 @@ import json
 import os
 import shutil
 import signal
+import threading
 from multiprocessing.pool import Pool
 import multiprocessing
 from enum import StrEnum
@@ -97,6 +98,13 @@ SYNC_CPE = strtobool(os.getenv("SYNC_CPE", "yes"))
 SYNC_CSAF = strtobool(os.getenv("SYNC_CSAF", "yes"))
 SYNC_RELEASES = strtobool(os.getenv("SYNC_RELEASES", "yes"))
 SYNC_RELEASE_GRAPH = strtobool(os.getenv("SYNC_RELEASE_GRAPH", "yes"))
+REPO_SYNC_QUEUE_INTERVAL_MINUTES = int(os.getenv("REPO_SYNC_QUEUE_INTERVAL_MINUTES", "5"))
+
+# Queue for per-repo sync requests from Satellite (IoP mode).
+# Stores tuples of (label, releasever_or_None, basearch_or_None).
+# Protected by a lock because BackgroundScheduler and HTTP workers access it concurrently.
+_repo_queue: set[tuple[str, str | None, str | None, str]] = set()
+_repo_queue_lock = threading.Lock()
 
 
 class TaskStatusResponse(dict):
@@ -738,6 +746,14 @@ class DbChangeHandler():
         return result
 
 
+def _queue_repo(label: str, releasever: str | None, basearch: str | None, organization: str) -> str:
+    """Add a repo to the sync queue. Deduplication is handled by set uniqueness."""
+    entry = (label, releasever, basearch, organization)
+    _repo_queue.add(entry)
+    return "Repository label '%s' (releasever=%s, basearch=%s, org=%s) added to sync queue. Queue size: %d, entries: %s" % (
+        label, releasever, basearch, organization, len(_repo_queue), _repo_queue)
+
+
 class RepoSyncHandler(SyncHandler):
     """Handler for repository sync API."""
 
@@ -746,7 +762,6 @@ class RepoSyncHandler(SyncHandler):
     @classmethod
     def put(cls, **kwargs):
         """Sync repositories stored in DB."""
-
         status_code, status_msg = cls.start_task()
         return status_msg, status_code
 
@@ -759,6 +774,66 @@ class RepoSyncHandler(SyncHandler):
             repository_controller = RepositoryController()
             repository_controller.add_db_repositories()
             repository_controller.store()
+        except Exception as err:  # pylint: disable=broad-except
+            msg = "Internal server error <%s>" % hash(err)
+            LOGGER.exception(msg)
+            DatabaseHandler.rollback()
+            if isinstance(err, DatabaseError):
+                return "DB_ERROR"
+            return "ERROR"
+        finally:
+            DatabaseHandler.close_connection()
+        return "OK"
+
+
+class RepoQueueHandler:
+    """Handler for queuing specific repositories for sync (IoP mode)."""
+
+    @staticmethod
+    def put(label, releasever=None, basearch=None, organization=None, **kwargs):
+        """Queue a specific repository for sync."""
+        org = organization or DEFAULT_ORG_NAME
+        with _repo_queue_lock:
+            msg = _queue_repo(label, releasever or None, basearch or None, org)
+        LOGGER.info(msg)
+        return TaskStartResponse(msg), 200
+
+
+class RepoQueueSyncHandler(SyncHandler):
+    """Handler for syncing only repositories queued via per-repo sync requests (IoP mode)."""
+
+    task_type = "Sync queued repositories"
+
+    @staticmethod
+    def run_task(*args, **kwargs):
+        """Sync only repositories that were queued by Satellite."""
+        queue: set[tuple[str, str | None, str | None, str]] = kwargs.get("queue", set())
+        try:
+            init_logging()
+            init_db()
+            controller = RepositoryController()
+            repos = controller.repo_store.list_repositories()
+            for (content_set, basearch, releasever, organization), repo_dict in repos.items():
+                for (q_label, q_releasever, q_basearch, q_org) in queue:
+                    if content_set != q_label:
+                        continue
+                    if q_releasever is not None and releasever != q_releasever:
+                        continue
+                    if q_basearch is not None and basearch != q_basearch:
+                        continue
+                    if organization != q_org:
+                        continue
+                    controller.repo_store.content_set_to_db_id[content_set] = repo_dict["content_set_id"]
+                    controller.add_repository(
+                        repo_dict["url"], content_set, basearch, releasever, organization,
+                        cert_name=repo_dict["cert_name"], ca_cert=repo_dict["ca_cert"],
+                        cert=repo_dict["cert"], key=repo_dict["key"],
+                    )
+                    break
+            if controller.repositories:
+                controller.store()
+            else:
+                LOGGER.info("No repositories found in DB for queue entries: %s, skipping sync.", queue)
         except Exception as err:  # pylint: disable=broad-except
             msg = "Internal server error <%s>" % hash(err)
             LOGGER.exception(msg)
@@ -1181,7 +1256,23 @@ def periodic_sync():
     AllSyncHandler.start_task()
 
 
-def create_app(specs):
+def sync_queued_repos():
+    """Process per-repo sync requests queued by Satellite (IoP mode)."""
+    if SyncTask.is_running():
+        LOGGER.info("Repo queue sync skipped: another task already in progress. Queue size: %d", len(_repo_queue))
+        return
+
+    with _repo_queue_lock:
+        if not _repo_queue:
+            return
+        queue = _repo_queue.copy()
+        _repo_queue.clear()
+
+    LOGGER.info("Processing %d queued repository entries: %s", len(queue), queue)
+    RepoQueueSyncHandler.start_task(queue=queue)
+
+
+def create_app(specs):  # pylint: disable=too-many-branches,too-many-statements
     """Create reposcan app."""
     init_logging()
     SyncTask.init()
@@ -1193,7 +1284,7 @@ def create_app(specs):
     metrics_refresh_interval = int(os.getenv('METRICS_GAUGE_REFRESH_INTERVAL_MINUTES', "240"))
 
     # Sync jobs to run
-    periodic_job_intervals = (sync_interval, metrics_refresh_interval)
+    periodic_job_intervals = (sync_interval, metrics_refresh_interval, REPO_SYNC_QUEUE_INTERVAL_MINUTES)
 
     sched = None
     if any(job > 0 for job in periodic_job_intervals):
@@ -1216,6 +1307,12 @@ def create_app(specs):
             LOGGER.warning("REPOSCAN_SYNC_INTERVAL_MINUTES is 0 - Certification metrics gauge may not show actual data.")
     else:
         LOGGER.info("Periodic metrics gauge disabled.")
+
+    if REPO_SYNC_QUEUE_INTERVAL_MINUTES > 0:
+        sched.add_job(sync_queued_repos, trigger="interval", minutes=REPO_SYNC_QUEUE_INTERVAL_MINUTES)
+        LOGGER.info("Repo queue sync running every %s minute(s).", REPO_SYNC_QUEUE_INTERVAL_MINUTES)
+    else:
+        LOGGER.info("Repo queue sync disabled.")
 
     if sched is not None:
         sched.start()

--- a/vmaas/reposcan/reposcan.spec.yaml
+++ b/vmaas/reposcan/reposcan.spec.yaml
@@ -160,6 +160,40 @@ paths:
       tags:
         - Sync
 
+  /sync/repo/queue:
+    post:
+      summary: Queue repositories for sync
+      operationId: vmaas.reposcan.reposcan.RepoQueueHandler.post
+      <<: *secured
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              minItems: 1
+              items:
+                type: object
+                required:
+                  - label
+                properties:
+                  label:
+                    type: string
+                    description: Content set label (e.g. rhel-8-for-x86_64-baseos-rpms)
+                  releasever:
+                    type: string
+                    description: Release version (e.g. 8.9). If omitted, all versions are queued.
+                  basearch:
+                    type: string
+                    description: Base architecture (e.g. x86_64). If omitted, all architectures are queued.
+                  organization:
+                    type: string
+                    description: Organization name. Defaults to DEFAULT if omitted.
+      responses:
+        <<: *sync_responses
+      tags:
+        - Sync
+
   /sync/cvemap:
     put:
       summary: Sync the CVE map

--- a/vmaas/reposcan/reposcan.spec.yaml
+++ b/vmaas/reposcan/reposcan.spec.yaml
@@ -160,6 +160,41 @@ paths:
       tags:
         - Sync
 
+  /sync/repo/queue:
+    put:
+      summary: Queue a specific repository for sync (IoP mode)
+      operationId: vmaas.reposcan.reposcan.RepoQueueHandler.put
+      <<: *secured
+      parameters:
+        - name: label
+          description: Content set label to queue for sync (e.g. rhel-8-for-x86_64-baseos-rpms)
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: releasever
+          description: Specific release version to queue (e.g. 8.9). If omitted, all versions of the label are queued.
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: basearch
+          description: Specific base architecture to queue (e.g. x86_64). If omitted, all architectures are queued.
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: organization
+          description: Organization name (e.g. org_id). Defaults to DEFAULT if omitted.
+          required: false
+          in: query
+          schema:
+            type: string
+      responses:
+        <<: *sync_responses
+      tags:
+        - Sync
+
   /sync/cvemap:
     put:
       summary: Sync the CVE map


### PR DESCRIPTION
RHINENG-20782

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Add support for queuing and periodically syncing individual repositories requested by Satellite, with configurable sync interval.

New Features:
- Introduce a per-repository sync queue API that allows Satellite to request syncs for specific content set labels, release versions, and architectures.
- Add a background job to process queued repository sync requests at a configurable interval.

Enhancements:
- Extend the repository sync handler to optionally enqueue targeted sync requests instead of triggering a full sync.
- Add subsumption logic to deduplicate and coalesce queued repository sync entries based on label, release version, and architecture.

Build:
- Expose REPO_SYNC_QUEUE_INTERVAL_MINUTES as an application configuration parameter in deployment manifests.