### PR TITLE
fix linting problem with context in gin.go

### DIFF
--- a/vmaas-go/base/utils/gin.go
+++ b/vmaas-go/base/utils/gin.go
@@ -80,10 +80,9 @@ func CheckLimitOffset(limit int, offset int) error {
 func RunServer(ctx context.Context, handler http.Handler, port int) error {
 	addr := fmt.Sprintf(":%d", port)
 	srv := http.Server{Addr: addr, Handler: handler, ReadHeaderTimeout: ReadHeaderTimeout, MaxHeaderBytes: 65535}
-	//nolint:gosec // G118: seems like a false positive, ctx is already closed so context.Background() is correct here
 	go func() {
 		<-ctx.Done()
-		err := srv.Shutdown(context.Background())
+		err := srv.Shutdown(context.WithoutCancel(ctx))
 		if err != nil {
 			LogError("err", err.Error(), "server shutting down failed")
 			return


### PR DESCRIPTION
Fixing the problem with Go lint. This change was approved in foreman branches https://github.com/RedHatInsights/vmaas/pull/1866/changes#diff-e9ad5ed1e3d168f4bf67469395bbf3d15c8bc82a2cdfddd62832c83c815840a7R85

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Use a non-cancelable context derived from the request context when shutting down the HTTP server instead of context.Background() to address a linting issue.