### PR TITLE
chore: switch to PostgreSQL 18 in dev env

### DIFF
--- a/.github/workflows/container-publish.yaml
+++ b/.github/workflows/container-publish.yaml
@@ -19,7 +19,7 @@ env:
   REGISTRY: quay.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: "iop/vmaas"
-  ALT_REPO: "https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo"
+  ALT_REPO: "https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-18/repo/rhel-9/group_insights-postgresql-18-rhel-9.repo"
 
 
 jobs:

--- a/.github/workflows/platsec-security-scan.yml
+++ b/.github/workflows/platsec-security-scan.yml
@@ -44,7 +44,7 @@ jobs:
     #   base_dockerbuild_path: './testbuild.base'
     #   base_dockerfile_path: './test'
     #   base_dockerfile_name: 'Dockerfile.base'
-        build_arg: '--build-arg ALT_REPO="https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo"'
+        build_arg: '--build-arg ALT_REPO="https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-18/repo/rhel-9/group_insights-postgresql-18-rhel-9.repo"'
     #   only_fixed: true
     #   fail_on_vulns: true
     #   severity_fail_cutoff: high

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785906621@sha256:dd334afa7
 ARG ALT_REPO
 
 ARG VAR_RPMS=""
-RUN (microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo $ALT_REPO) && \
+RUN (microdnf module enable -y postgresql:18 || curl -o /etc/yum.repos.d/postgresql.repo $ALT_REPO) && \
     microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
         go-toolset rpm-devel python3.12-pip cargo rust python3.12-devel libffi-devel postgresql-devel openssl-devel \
         $VAR_RPMS && \
@@ -33,7 +33,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785906621@sha256:dd334afa7
 
 ARG ALT_REPO
 
-RUN (microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo $ALT_REPO) && \
+RUN (microdnf module enable -y postgresql:18 || curl -o /etc/yum.repos.d/postgresql.repo $ALT_REPO) && \
     microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
         python312 python3-rpm python3-dnf which git-core shadow-utils diffutils systemd libicu postgresql libpq && \
         ln -s /usr/lib64/python3.9/site-packages/rpm /usr/lib64/python3.12/site-packages/rpm && \

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 services:
   vmaas_database:
     container_name: vmaas-database
-    image: docker.io/library/postgres:16
+    image: docker.io/library/postgres:18
     restart: unless-stopped
     environment:
       POSTGRES_DB: vmaas
@@ -17,7 +17,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        ALT_REPO: "https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo"
+        ALT_REPO: "https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-18/repo/rhel-9/group_insights-postgresql-18-rhel-9.repo"
         VAR_RPMS: "findutils git-core postgresql"
         VAR_PIP_INSTALL_OPT: "-r requirements-dev.txt"
       target: buildimg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   vmaas_database:
     container_name: vmaas-database
-    image: docker.io/library/postgres:16
+    image: docker.io/library/postgres:18
     restart: unless-stopped
     shm_size: '256mb'
     environment:
@@ -11,7 +11,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - vmaas-db-data:/var/lib/postgresql/data
+      - vmaas-db-data:/var/lib/postgresql
 
   vmaas_reposcan:
     command: /vmaas/entrypoint.sh reposcan
@@ -22,7 +22,7 @@ services:
       dockerfile: ./Dockerfile
       args:
         REQUIRE_RHEL: "no"
-        ALT_REPO: "https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo"
+        ALT_REPO: "https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-18/repo/rhel-9/group_insights-postgresql-18-rhel-9.repo"
     image: vmaas/app:latest
     restart: unless-stopped
     env_file:

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -4,4 +4,4 @@ contentOrigin:
 arches: [x86_64]
 
 moduleEnable:
-  - postgresql:16
+  - postgresql:18

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -88,13 +88,13 @@ arches:
     name: golang-src
     evr: 1.26.5-1.el9_8
     sourcerpm: golang-1.26.5-1.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.34.1.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.36.1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 2901917
-    checksum: sha256:504e15343d3288cab0146755376113e17220e5837250aa9ab186fb2a56f812ed
+    size: 2903853
+    checksum: sha256:aa8f8d4579635787d6dda7323d472de1f2f630f97d694ebf5e0208791b76555c
     name: kernel-headers
-    evr: 5.14.0-687.34.1.el9_8
-    sourcerpm: kernel-5.14.0-687.34.1.el9_8.src.rpm
+    evr: 5.14.0-687.36.1.el9_8
+    sourcerpm: kernel-5.14.0-687.36.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libffi-devel-3.4.2-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 32520
@@ -186,20 +186,20 @@ arches:
     name: popt-devel
     evr: 1.18-8.el9
     sourcerpm: popt-1.18-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/postgresql-16.14-1.module+el9.8.0+24360+ff98e86a.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/postgresql-18.4-2.module+el9.8.0+24359+da7fad50.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 2058539
-    checksum: sha256:9325e51249f2c5c94ebe82805f66e37574f6757504b394f4c1ee44733a4d7b2d
+    size: 2155327
+    checksum: sha256:fa4fe5e4d4e9df24295ce6910c4f085c8938b0b44853495fc3c85c42828dbc5f
     name: postgresql
-    evr: 16.14-1.module+el9.8.0+24360+ff98e86a
-    sourcerpm: postgresql-16.14-1.module+el9.8.0+24360+ff98e86a.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/postgresql-private-libs-16.14-1.module+el9.8.0+24360+ff98e86a.x86_64.rpm
+    evr: 18.4-2.module+el9.8.0+24359+da7fad50
+    sourcerpm: postgresql-18.4-2.module+el9.8.0+24359+da7fad50.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/postgresql-private-libs-18.4-2.module+el9.8.0+24359+da7fad50.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 153300
-    checksum: sha256:c637e020443076818c6b8d271fc49090f52fef850b12aa3f1068d695293b9991
+    size: 167946
+    checksum: sha256:71f7e51e54c450532e656cbcd3b14e9454cc584076d6bf6e475369d4ad4ba1ec
     name: postgresql-private-libs
-    evr: 16.14-1.module+el9.8.0+24360+ff98e86a
-    sourcerpm: postgresql-16.14-1.module+el9.8.0+24360+ff98e86a.src.rpm
+    evr: 18.4-2.module+el9.8.0+24359+da7fad50
+    sourcerpm: postgresql-18.4-2.module+el9.8.0+24359+da7fad50.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.25-7.el9_8.2.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 16175
@@ -760,12 +760,12 @@ arches:
     checksum: sha256:2f5ece89d6a8d892816f386462d8be291ad83f1500b4c4b3655dcc7ed5192c0d
     name: mpdecimal
     evr: 2.5.1-3.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/postgresql-16.14-1.module+el9.8.0+24360+ff98e86a.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/postgresql-18.4-2.module+el9.8.0+24359+da7fad50.src.rpm
     repoid: rhel-9-for-x86_64-appstream-source-rpms
-    size: 48442323
-    checksum: sha256:a6e5d5ae3807b707632863dd9f2c628d7b269710433ab0af08ab65ee678b8e45
+    size: 47663882
+    checksum: sha256:7e6722b01c3aade7be4f1b6f5ac81085fd7c1f72bf9320415de0c785e619a704
     name: postgresql
-    evr: 16.14-1.module+el9.8.0+24360+ff98e86a
+    evr: 18.4-2.module+el9.8.0+24359+da7fad50
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/python3.12-3.12.13-3.el9_8.1.src.rpm
     repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 20886822
@@ -886,12 +886,12 @@ arches:
     checksum: sha256:645080ac16b4cc7d858b419642ae8a606d7f637e721a6eb7be5203bc3eb6c995
     name: ima-evm-utils
     evr: 1.6.2-2.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kernel-5.14.0-687.34.1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kernel-5.14.0-687.36.1.el9_8.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 152352999
-    checksum: sha256:d81d657306ead869018f099e0dc5ea3dc7dcae832f7b0d03d1279bd2da65aed6
+    size: 152382286
+    checksum: sha256:c57c1b970d690b22348675c3983ace878fcf457ad4b580018e08ec4b689be0b1
     name: kernel
-    evr: 5.14.0-687.34.1.el9_8
+    evr: 5.14.0-687.36.1.el9_8
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/keyutils-1.6.3-1.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 150790
@@ -1079,7 +1079,7 @@ arches:
     name: zstd
     evr: 1.5.5-1.el9
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/repodata/a7289e240e9f9f0ceafbbe5f6700569b7dca58d49066e9c1978312eb7b90ca6b-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/repodata/4b318bd8815359778940acba8bf66bc594c6560aaf872afc8f8264fddba24da4-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 64235
-    checksum: sha256:a7289e240e9f9f0ceafbbe5f6700569b7dca58d49066e9c1978312eb7b90ca6b
+    size: 65787
+    checksum: sha256:4b318bd8815359778940acba8bf66bc594c6560aaf872afc8f8264fddba24da4


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Update development and testing environments to use PostgreSQL 18 instead of PostgreSQL 16, aligning containers, RPM module configuration, and CI workflows with the newer database version.

Enhancements:
- Refresh kernel header and source RPM references in rpms.lock.yaml to newer RHEL 9.8 builds.
- Adjust PostgreSQL-related RPM locks and module metadata to track the PostgreSQL 18.4 stream in rpms.lock.yaml.
- Update Dockerfile base image configuration to enable and install the PostgreSQL 18 module for build and runtime layers.

Build:
- Switch Docker and docker-compose configurations to PostgreSQL 18 images and data directory layout.
- Change ALT_REPO build arguments and moduleEnable configuration to point to PostgreSQL 18 COPR/RHEL 9 repositories.

CI:
- Update container-publish and security-scan GitHub workflows to pass PostgreSQL 18 ALT_REPO build arguments.