### PR TITLE
ci: enable signing generated requirements.txt commits

### DIFF
--- a/.github/workflows/generate-requirements-txt.yaml
+++ b/.github/workflows/generate-requirements-txt.yaml
@@ -14,6 +14,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure SSH commit signing
+        env:
+          SIGNING_KEY: ${{ secrets.SEMANTIC_RELEASE_SIGNING_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SIGNING_KEY" > ~/.ssh/signing_key
+          chmod 600 ~/.ssh/signing_key
+          git config --global gpg.format ssh
+          git config --global user.signingkey ~/.ssh/signing_key
+          git config --global commit.gpgSign true
+          git config --global tag.gpgSign true
+
       - name: Install Python tools
         run: |
           # https://github.com/hermetoproject/pybuild-deps/issues/295
@@ -36,8 +48,8 @@ jobs:
 
       - name: Commit and Push
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "vmaas-bot"
+          git config --global user.email "40663028+vmaas-bot@users.noreply.github.com"
 
           git add .
           


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Enable signed commits and tags for the generated requirements.txt workflow using an SSH-based signing key and update the bot identity used for committing changes.

CI:
- Configure SSH-based GPG signing in the generate-requirements-txt GitHub Actions workflow so that commits and tags are signed.
- Update the committing user in the requirements generation workflow to use the vmaas-bot identity instead of github-actions[bot].