### PR TITLE
chore: make git ref configurable

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -154,6 +154,8 @@ objects:
           value: ${KEEP_COPIES}
         - name: REPOLIST_GIT
           value: ${REPOLIST_GIT}
+        - name: REPOLIST_GIT_REF
+          value: ${REPOLIST_GIT_REF}
         - name: REPOLIST_PATH
           value: ${REPOLIST_GIT_PATH}
         - name: REPOLIST_GIT_TOKEN
@@ -366,6 +368,9 @@ parameters:
   value: '360'
 - name: REPOLIST_GIT
   description: Location of VMaaS assets git
+- name: REPOLIST_GIT_REF
+  description: Git ref to sync vmaas-assets from
+  value: master
 - name: REPOLIST_GIT_PATH
   description: Path/comma separated paths, denoting repolist files in the git repo
   value: "repolist.json, epel-repolist.json"


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Make the VMaaS assets Git synchronization ref configurable, defaulting to master.

New Features:
- Allow deployments to configure the Git ref used to synchronize VMaaS assets.

Deployment:
- Expose the configurable VMaaS assets Git ref through the ClowdApp deployment parameters and environment.