### PR TITLE
fix: regenerate swagger api docs

### DIFF
--- a/vmaas-go/docs/openapi.json
+++ b/vmaas-go/docs/openapi.json
@@ -1,0 +1,2880 @@
+{
+  "components": {
+    "schemas": {
+      "utils.ErrorResponse": {
+        "description": "Universal error response for all VMaaS endpoints.",
+        "properties": {
+          "detail": {
+            "description": "error message",
+            "type": "string"
+          },
+          "status": {
+            "description": "status code",
+            "type": "integer"
+          },
+          "title": {
+            "description": "status text",
+            "type": "string"
+          },
+          "type": {
+            "description": "\"about:blank\"",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.AffectedPackage": {
+        "properties": {
+          "cpe": {
+            "type": "string"
+          },
+          "evra": {
+            "type": "string"
+          },
+          "module_name": {
+            "example": "rhn-tools",
+            "type": "string"
+          },
+          "module_stream": {
+            "example": "1",
+            "type": "string"
+          },
+          "package_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "module_name",
+          "module_stream"
+        ],
+        "type": "object"
+      },
+      "vmaas.ContentData": {
+        "additionalProperties": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": "TODO: use `omitzero` from go1.24",
+        "type": "object"
+      },
+      "vmaas.CveDetail": {
+        "properties": {
+          "cvss2_metrics": {
+            "example": "AV:L/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N",
+            "type": "string"
+          },
+          "cvss2_score": {
+            "example": "5.600",
+            "type": "string"
+          },
+          "cvss3_metrics": {
+            "example": "AV:L/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N",
+            "type": "string"
+          },
+          "cvss3_score": {
+            "example": "5.1",
+            "type": "string"
+          },
+          "cwe_list": {
+            "example": [
+              "CWE-20"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "description": {
+            "example": "description text",
+            "type": "string"
+          },
+          "errata_list": {
+            "example": [
+              "RHSA-2015:1981"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "impact": {
+            "enum": [
+              "NotSet",
+              "None",
+              "Low",
+              "Medium",
+              "Moderate",
+              "Important",
+              "High",
+              "Critical"
+            ],
+            "type": "string"
+          },
+          "modified_date": {
+            "example": "2018-03-31T01:29:00+00:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "package_list": {
+            "example": [
+              "nss-devel-3.16.1-9.el6_5.x86_64"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "public_date": {
+            "example": "2018-01-04T13:29:00+00:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "redhat_url": {
+            "example": "https://access.redhat.com/security/cve/cve-2017-5715",
+            "type": "string"
+          },
+          "secondary_url": {
+            "example": "https://seconday.url.com",
+            "type": "string"
+          },
+          "source_package_list": {
+            "example": [
+              "nss-devel-3.16.1-9.el6_5.src"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "synopsis": {
+            "example": "CVE-2017-5715",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.CveDetails": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/vmaas.CveDetail"
+        },
+        "type": "object"
+      },
+      "vmaas.Cves": {
+        "properties": {
+          "cve_list": {
+            "$ref": "#/components/schemas/vmaas.CveDetails"
+          },
+          "last_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "page_size": {
+            "type": "integer"
+          },
+          "pages": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.CvesRequest": {
+        "properties": {
+          "cve_list": {
+            "example": [
+              "CVE-2017-57.*"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "errata_associated": {
+            "description": "Return only those CVEs which are associated with at least one errata. Defaults to false.",
+            "type": "boolean"
+          },
+          "modified_since": {
+            "example": "2018-04-05T01:23:45+02:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "page": {
+            "example": 1,
+            "type": "integer"
+          },
+          "page_size": {
+            "example": 10,
+            "type": "integer"
+          },
+          "published_since": {
+            "example": "2018-04-05T01:23:45+02:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "rh_only": {
+            "type": "boolean"
+          },
+          "third_party": {
+            "default": false,
+            "description": "Include content from \\\"third party\\\" repositories into the response, disabled by default.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "cve_list"
+        ],
+        "type": "object"
+      },
+      "vmaas.DBChange": {
+        "description": "VMaaS DB last-updated time stramps",
+        "properties": {
+          "cve_changes": {
+            "example": "2024-11-20T12:26:20.009512Z",
+            "type": "string"
+          },
+          "errata_changes": {
+            "example": "2024-11-20T12:24:23.488871Z",
+            "type": "string"
+          },
+          "exported": {
+            "example": "2024-11-20T12:37:47.605526Z",
+            "type": "string"
+          },
+          "last_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          },
+          "repository_changes": {
+            "example": "2024-11-20T12:24:23.486827Z",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.Errata": {
+        "properties": {
+          "errata_list": {
+            "$ref": "#/components/schemas/vmaas.ErratumDetails"
+          },
+          "last_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "page_size": {
+            "type": "integer"
+          },
+          "pages": {
+            "type": "integer"
+          },
+          "severity": {
+            "items": {
+              "enum": [
+                "Low",
+                "Moderate",
+                "Important",
+                "Critical",
+                "null",
+                "Low",
+                "Moderate",
+                "Important",
+                "Critical",
+                "null"
+              ],
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "type": {
+            "example": [
+              "security"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.ErrataRequest": {
+        "properties": {
+          "errata_list": {
+            "example": [
+              "RHSA-2018:05.*"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "modified_since": {
+            "example": "2018-04-05T01:23:45+02:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "page": {
+            "example": 1,
+            "type": "integer"
+          },
+          "page_size": {
+            "example": 10,
+            "type": "integer"
+          },
+          "severity": {
+            "items": {
+              "enum": [
+                "Low",
+                "Moderate",
+                "Important",
+                "Critical",
+                "null",
+                "Low",
+                "Moderate",
+                "Important",
+                "Critical",
+                "null"
+              ],
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "third_party": {
+            "default": false,
+            "description": "Include content from \\\"third party\\\" repositories into the response, disabled by default.",
+            "type": "boolean"
+          },
+          "type": {
+            "example": [
+              "security"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "required": [
+          "errata_list"
+        ],
+        "type": "object"
+      },
+      "vmaas.ErratumDetail": {
+        "properties": {
+          "bugzilla_list": {
+            "example": [
+              "1519778"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "cve_list": {
+            "example": [
+              "CVE-2017-5715"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "description": {
+            "example": "description text",
+            "type": "string"
+          },
+          "issued": {
+            "example": "2018-03-13T17:31:28+00:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "modules_list": {
+            "items": {
+              "$ref": "#/components/schemas/vmaas.Module"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "package_list": {
+            "example": [
+              "kernel-2.6.32-696.23.1.el6.x86_64"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "reference_list": {
+            "example": [
+              "classification-RHSA-2018:0512"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "release_versions": {
+            "example": [
+              "8.1"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "requires_reboot": {
+            "type": "boolean"
+          },
+          "severity": {
+            "enum": [
+              "Low",
+              "Moderate",
+              "Important",
+              "Critical",
+              "null"
+            ],
+            "type": "string"
+          },
+          "solution": {
+            "example": "solution text",
+            "type": "string"
+          },
+          "source_package_list": {
+            "example": [
+              "kernel-2.6.32-696.23.1.el6.src"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "summary": {
+            "example": "summary text",
+            "type": "string"
+          },
+          "synopsis": {
+            "example": "Important: kernel security and bug fix update",
+            "type": "string"
+          },
+          "third_party": {
+            "type": "boolean"
+          },
+          "type": {
+            "example": "security",
+            "type": "string"
+          },
+          "updated": {
+            "example": "2018-03-13T17:31:41+00:00",
+            "type": "string"
+          },
+          "url": {
+            "example": "https://access.redhat.com/errata/RHSA-2018:0512",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.ErratumDetails": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/vmaas.ErratumDetail"
+        },
+        "type": "object"
+      },
+      "vmaas.Module": {
+        "properties": {
+          "module_context": {
+            "type": "string"
+          },
+          "module_name": {
+            "type": "string"
+          },
+          "module_stream": {
+            "type": "string"
+          },
+          "module_version": {
+            "type": "integer"
+          },
+          "package_list": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "source_package_list": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.ModuleStream": {
+        "properties": {
+          "module_name": {
+            "type": "string"
+          },
+          "module_stream": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.ModuleStreamPtrs": {
+        "properties": {
+          "module_name": {
+            "example": "rhn-tools",
+            "type": "string"
+          },
+          "module_stream": {
+            "example": "1",
+            "type": "string"
+          }
+        },
+        "required": [
+          "module_name",
+          "module_stream"
+        ],
+        "type": "object"
+      },
+      "vmaas.OSReleaseDetail": {
+        "properties": {
+          "cves_critical": {
+            "type": "integer"
+          },
+          "cves_important": {
+            "type": "integer"
+          },
+          "cves_low": {
+            "type": "integer"
+          },
+          "cves_moderate": {
+            "type": "integer"
+          },
+          "cves_unpatched_critical": {
+            "type": "integer"
+          },
+          "cves_unpatched_important": {
+            "type": "integer"
+          },
+          "cves_unpatched_low": {
+            "type": "integer"
+          },
+          "cves_unpatched_moderate": {
+            "type": "integer"
+          },
+          "lifecycle_phase": {
+            "type": "string"
+          },
+          "major": {
+            "type": "integer"
+          },
+          "minor": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.PackageDetails": {
+        "additionalProperties": {},
+        "type": "object"
+      },
+      "vmaas.Packages": {
+        "properties": {
+          "last_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          },
+          "package_list": {
+            "$ref": "#/components/schemas/vmaas.PackageDetails"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.PackagesRequest": {
+        "properties": {
+          "package_list": {
+            "example": [
+              "kernel-2.6.32-696.20.1.el6.x86_64"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "third_party": {
+            "default": false,
+            "description": "Include content from \"third party\" repositories into the response, disabled by default.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "package_list"
+        ],
+        "type": "object"
+      },
+      "vmaas.Patches": {
+        "properties": {
+          "errata_list": {
+            "example": [
+              "RHSA-2018:0151"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "last_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.PkgList": {
+        "properties": {
+          "last_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          },
+          "package_list": {
+            "items": {
+              "$ref": "#/components/schemas/vmaas.PkgListItem"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "page": {
+            "type": "integer"
+          },
+          "page_size": {
+            "type": "integer"
+          },
+          "pages": {
+            "type": "integer"
+          },
+          "total": {
+            "description": "Total number of packages to return.",
+            "example": 100,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.PkgListItem": {
+        "properties": {
+          "description": {
+            "example": "My package description",
+            "type": "string"
+          },
+          "modified": {
+            "example": "2018-04-05T01:23:45+02:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "nevra": {
+            "example": "kernel-rt-4.18.0-147.rt24.93.el8.x86_64",
+            "type": "string"
+          },
+          "summary": {
+            "example": "My package summary",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.PkgTree": {
+        "properties": {
+          "last_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          },
+          "package_name_list": {
+            "$ref": "#/components/schemas/vmaas.PkgTreeItems"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "page_size": {
+            "type": "integer"
+          },
+          "pages": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.PkgTreeErratumDetail": {
+        "properties": {
+          "cve_list": {
+            "example": [
+              "CVE-2018-13405"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "issued": {
+            "example": "2019-11-19T09:41:05+00:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "example": "RHSA-2019:2730",
+            "type": "string"
+          },
+          "updated": {
+            "example": "2019-11-19T09:41:05+00:00",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "issued",
+          "name"
+        ],
+        "type": "object"
+      },
+      "vmaas.PkgTreeItem": {
+        "properties": {
+          "description": {
+            "example": "My package description",
+            "type": "string"
+          },
+          "errata": {
+            "items": {
+              "$ref": "#/components/schemas/vmaas.PkgTreeErratumDetail"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "first_published": {
+            "description": "Example: 2020-01-13T17:31:41+00:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "nevra": {
+            "description": "Example: kernel-rt-4.18.0-147.rt24.93.el8.x86_64",
+            "type": "string"
+          },
+          "repositories": {
+            "items": {
+              "$ref": "#/components/schemas/vmaas.PkgTreeRepoDetail"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "summary": {
+            "example": "My package summary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_published",
+          "nevra"
+        ],
+        "type": "object"
+      },
+      "vmaas.PkgTreeItems": {
+        "additionalProperties": {
+          "items": {
+            "$ref": "#/components/schemas/vmaas.PkgTreeItem"
+          },
+          "type": "array"
+        },
+        "type": "object"
+      },
+      "vmaas.PkgTreeRepoDetail": {
+        "properties": {
+          "basearch": {
+            "example": "x86_64",
+            "type": "string"
+          },
+          "label": {
+            "example": "rhel-6-server-rpms",
+            "type": "string"
+          },
+          "name": {
+            "example": "Red Hat Enterprise Linux 6 Server (RPMs)",
+            "type": "string"
+          },
+          "organization": {
+            "type": "string"
+          },
+          "releasever": {
+            "example": "6Server",
+            "type": "string"
+          },
+          "revision": {
+            "example": "2019-11-19T09:41:05+00:00",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "basearch",
+          "label",
+          "name",
+          "releasever",
+          "revision"
+        ],
+        "type": "object"
+      },
+      "vmaas.PkgTreeRequest": {
+        "properties": {
+          "modified_since": {
+            "example": "2018-04-05T01:23:45+02:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "package_name_list": {
+            "example": [
+              "kernel-rt"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "page": {
+            "example": 1,
+            "type": "integer"
+          },
+          "page_size": {
+            "example": 10,
+            "type": "integer"
+          },
+          "return_description": {
+            "default": false,
+            "description": "Include nevra description info into the response.",
+            "type": "boolean"
+          },
+          "return_errata": {
+            "default": true,
+            "description": "Include nevra errata info into the response.",
+            "type": "boolean"
+          },
+          "return_repositories": {
+            "default": true,
+            "description": "Include nevra repositories info into the response.",
+            "type": "boolean"
+          },
+          "return_summary": {
+            "default": false,
+            "description": "Include nevra summary info into the response.",
+            "type": "boolean"
+          },
+          "third_party": {
+            "default": false,
+            "description": "Include content from \"third party\" repositories into the response, disabled by default.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "package_name_list"
+        ],
+        "type": "object"
+      },
+      "vmaas.RPMData": {
+        "additionalProperties": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        },
+        "type": "object"
+      },
+      "vmaas.RPMPkgNames": {
+        "properties": {
+          "last_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          },
+          "rpm_name_list": {
+            "$ref": "#/components/schemas/vmaas.ContentData"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.RPMPkgNamesRequest": {
+        "properties": {
+          "content_set_list": {
+            "example": [
+              "rhel-7-desktop-rpms"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "rpm_name_list": {
+            "example": [
+              "openssl-libs"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "required": [
+          "rpm_name_list"
+        ],
+        "type": "object"
+      },
+      "vmaas.RepoDetail": {
+        "properties": {
+          "basearch": {
+            "example": "x86_64",
+            "type": "string"
+          },
+          "cpes": {
+            "example": [
+              "cpe:/a:redhat"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "label": {
+            "example": "rhel-6-server-rpms",
+            "type": "string"
+          },
+          "last_change": {
+            "type": "string"
+          },
+          "name": {
+            "example": "Red Hat Enterprise Linux 6 Server (RPMs)",
+            "type": "string"
+          },
+          "organization": {
+            "type": "string"
+          },
+          "product": {
+            "example": "Red Hat Enterprise Linux Server",
+            "type": "string"
+          },
+          "releasever": {
+            "example": "6Server",
+            "type": "string"
+          },
+          "revision": {
+            "example": "2018-03-27T10:55:16+00:00",
+            "type": "string"
+          },
+          "third_party": {
+            "type": "boolean"
+          },
+          "updated_package_names": {
+            "example": [
+              "kernel"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "url": {
+            "example": "https://cdn.redhat.com/content/dist/rhel/server/6/6Server/x86_64/os/",
+            "type": "string"
+          }
+        },
+        "required": [
+          "basearch",
+          "label",
+          "name",
+          "releasever"
+        ],
+        "type": "object"
+      },
+      "vmaas.RepoDetails": {
+        "additionalProperties": {
+          "items": {
+            "$ref": "#/components/schemas/vmaas.RepoDetail"
+          },
+          "type": "array"
+        },
+        "type": "object"
+      },
+      "vmaas.Repos": {
+        "properties": {
+          "last_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          },
+          "latest_repo_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "page_size": {
+            "type": "integer"
+          },
+          "pages": {
+            "type": "integer"
+          },
+          "repository_list": {
+            "$ref": "#/components/schemas/vmaas.RepoDetails"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.ReposRequest": {
+        "properties": {
+          "has_packages": {
+            "default": false,
+            "description": "Return only repositories having advisories with packages released since the last modified_since",
+            "type": "boolean"
+          },
+          "modified_since": {
+            "description": "Return only repositories changed after the given date",
+            "example": "2018-04-05T01:23:45+02:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "organization": {
+            "type": "string"
+          },
+          "page": {
+            "example": 1,
+            "type": "integer"
+          },
+          "page_size": {
+            "example": 10,
+            "type": "integer"
+          },
+          "repository_list": {
+            "example": [
+              "rhel-6-server-rpms"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "show_packages": {
+            "default": false,
+            "description": "Show updated package names in a repo since the last modified_since",
+            "type": "boolean"
+          },
+          "third_party": {
+            "default": false,
+            "description": "Include content from \\\"third party\\\" repositories into the response, disabled by default.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "repository_list"
+        ],
+        "type": "object"
+      },
+      "vmaas.Request": {
+        "properties": {
+          "basearch": {
+            "example": "x86_64",
+            "type": "string"
+          },
+          "epoch_required": {
+            "type": "boolean"
+          },
+          "extended": {
+            "type": "boolean"
+          },
+          "latest_only": {
+            "type": "boolean"
+          },
+          "modules_list": {
+            "items": {
+              "$ref": "#/components/schemas/vmaas.ModuleStreamPtrs"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "organization": {
+            "type": "string"
+          },
+          "package_list": {
+            "example": [
+              "kernel-2.6.32-696.20.1.el6.x86_64"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "releasever": {
+            "example": "6Server",
+            "type": "string"
+          },
+          "repository_list": {
+            "example": [
+              "rhel-6-server-rpms"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "repository_paths": {
+            "example": [
+              "/content/dist/rhel/rhui/server/7/7Server/x86_64/os/"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "security_only": {
+            "type": "boolean"
+          },
+          "third_party": {
+            "default": false,
+            "description": "Include content from \"third party\" repositories into the response, disabled by default.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "package_list"
+        ],
+        "type": "object"
+      },
+      "vmaas.SRPMPkgNames": {
+        "properties": {
+          "last_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          },
+          "srpm_name_list": {
+            "$ref": "#/components/schemas/vmaas.RPMData"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.SRPMPkgNamesRequest": {
+        "properties": {
+          "content_set_list": {
+            "example": [
+              "rhel-7-desktop-rpms"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "srpm_name_list": {
+            "example": [
+              "openssl"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "required": [
+          "srpm_name_list"
+        ],
+        "type": "object"
+      },
+      "vmaas.Update": {
+        "properties": {
+          "basearch": {
+            "example": "x86_64",
+            "type": "string"
+          },
+          "erratum": {
+            "example": "RHSA-2018:0512",
+            "type": "string"
+          },
+          "evra": {
+            "example": "0:2.6.32-696.23.1.el6.x86_64",
+            "type": "string"
+          },
+          "package": {
+            "example": "kernel-2.6.32-696.23.1.el6.x86_64",
+            "type": "string"
+          },
+          "package_name": {
+            "example": "kernel",
+            "type": "string"
+          },
+          "releasever": {
+            "example": "6Server",
+            "type": "string"
+          },
+          "repository": {
+            "example": "rhel-6-server-rpms",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.UpdateDetail": {
+        "properties": {
+          "available_updates": {
+            "items": {
+              "$ref": "#/components/schemas/vmaas.Update"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.UpdateList": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/vmaas.UpdateDetail"
+        },
+        "type": "object"
+      },
+      "vmaas.Updates": {
+        "properties": {
+          "basearch": {
+            "example": "x86_64",
+            "type": "string"
+          },
+          "last_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          },
+          "modules_list": {
+            "items": {
+              "$ref": "#/components/schemas/vmaas.ModuleStream"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "releasever": {
+            "example": "6Server",
+            "type": "string"
+          },
+          "repository_list": {
+            "example": [
+              "rhel-6-server-rpms"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "repository_paths": {
+            "description": "Example: /content/dist/rhel/rhui/server/7/7Server/x86_64/os/",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "update_list": {
+            "$ref": "#/components/schemas/vmaas.UpdateList"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.Vulnerabilities": {
+        "properties": {
+          "cve_list": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "last_change": {
+            "example": "2024-11-20T12:36:49.640592Z",
+            "type": "string"
+          },
+          "manually_fixable_cve_list": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "unpatched_cve_list": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "required": [
+          "cve_list",
+          "manually_fixable_cve_list",
+          "unpatched_cve_list"
+        ],
+        "type": "object"
+      },
+      "vmaas.VulnerabilitiesExtended": {
+        "properties": {
+          "cve_list": {
+            "items": {
+              "$ref": "#/components/schemas/vmaas.VulnerabilityDetail"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "last_change": {
+            "type": "string"
+          },
+          "manually_fixable_cve_list": {
+            "items": {
+              "$ref": "#/components/schemas/vmaas.VulnerabilityDetail"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "unpatched_cve_list": {
+            "items": {
+              "$ref": "#/components/schemas/vmaas.VulnerabilityDetail"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.VulnerabilityDetail": {
+        "properties": {
+          "affected": {
+            "items": {
+              "$ref": "#/components/schemas/vmaas.AffectedPackage"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "cve": {
+            "type": "string"
+          },
+          "errata": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "type": "object"
+          },
+          "packages": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "vmaas.VulnerabilityReport": {
+        "properties": {
+          "last_change": {
+            "type": "string"
+          },
+          "os_releases": {
+            "items": {
+              "$ref": "#/components/schemas/vmaas.OSReleaseDetail"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "description": "API of the VMaaS application on [console.redhat.com](https://console.redhat.com)",
+    "license": {
+      "name": "GPLv3",
+      "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
+    },
+    "title": "VMaaS webapp API",
+    "version": "3.11.1"
+  },
+  "externalDocs": {
+    "description": "",
+    "url": ""
+  },
+  "paths": {
+    "/cves": {
+      "post": {
+        "description": "Get details about CVEs with additional parameters. Use `cve_list` parameter to provide a list of CVE names, or a single POSIX regular expression.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vmaas.CvesRequest",
+                    "summary": "cve_list",
+                    "description": "cve_list"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "cve_list",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Cves"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          }
+        },
+        "summary": "Get details for CVEs"
+      }
+    },
+    "/cves/{cve}": {
+      "get": {
+        "description": "Get details for a CVE. It is possible to use a POSIX regular expression as a pattern for CVE names.",
+        "parameters": [
+          {
+            "description": "CVE",
+            "in": "path",
+            "name": "cve",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Cves"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          }
+        },
+        "summary": "Get details for a CVE"
+      }
+    },
+    "/dbchange": {
+      "get": {
+        "description": "Get last-updated times from VMaaS DB.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.DBChange"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get last-updated times from VMaaS DB"
+      }
+    },
+    "/errata": {
+      "post": {
+        "description": "Get details about errata with additional parameters. Use `errata_list` parameter to provide a list of errata names, or a single POSIX regular expression.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vmaas.ErrataRequest",
+                    "summary": "errata_list",
+                    "description": "errata_list"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "errata_list",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Errata"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get details for errata"
+      }
+    },
+    "/errata/{erratum}": {
+      "get": {
+        "description": "Get details about an erratum. It is possible to use a POSIX regular expression as a pattern for errata names.",
+        "parameters": [
+          {
+            "description": "erratum",
+            "in": "path",
+            "name": "erratum",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Errata"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get details for an erratum"
+      }
+    },
+    "/os/vulnerability/report": {
+      "get": {
+        "description": "get OS vulnerability report",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.VulnerabilityReport"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get OS vulnerability report"
+      }
+    },
+    "/package_names/rpms": {
+      "post": {
+        "description": "Get a list of content sets by RPM name and content sets.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vmaas.RPMPkgNamesRequest",
+                    "summary": "rpm_name_list",
+                    "description": "rpm_name_list"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "rpm_name_list",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.RPMPkgNames"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get a list of content sets by RPM name and content sets"
+      }
+    },
+    "/package_names/rpms/{rpm}": {
+      "get": {
+        "description": "Get a list of content sets by RPM name.",
+        "parameters": [
+          {
+            "description": "RPM name",
+            "in": "path",
+            "name": "rpm",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.RPMPkgNames"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get a list of content sets by RPM name"
+      }
+    },
+    "/package_names/srpms": {
+      "post": {
+        "description": "Get content sets with associated RPM names by SRPM and content sets.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vmaas.SRPMPkgNamesRequest",
+                    "summary": "srpm_name_list",
+                    "description": "srpm_name_list"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "srpm_name_list",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.SRPMPkgNames"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get content sets with associated RPM names by SRPM and content sets"
+      }
+    },
+    "/package_names/srpms/{srpm}": {
+      "get": {
+        "description": "Get content sets with associated RPM names by SRPM.",
+        "parameters": [
+          {
+            "description": "SRPM name",
+            "in": "path",
+            "name": "srpm",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.SRPMPkgNames"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get content sets with associated RPM names by SRPM"
+      }
+    },
+    "/packages": {
+      "post": {
+        "description": "Get details about packages. Use `package_list` to provide a list of package NEVRAs.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vmaas.PackagesRequest",
+                    "summary": "package_list",
+                    "description": "package_list"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "package_list",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Packages"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get details for packages"
+      }
+    },
+    "/packages/{nevra}": {
+      "get": {
+        "description": "Get details about a package.",
+        "parameters": [
+          {
+            "description": "NEVRA",
+            "in": "path",
+            "name": "nevra",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Packages"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get details for a package"
+      }
+    },
+    "/patches": {
+      "post": {
+        "description": "Get a list of applicable errata for a package list.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vmaas.Request",
+                    "summary": "package_list",
+                    "description": "package_list"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "package_list",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Patches"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get patches for packages"
+      }
+    },
+    "/patches/{nevra}": {
+      "get": {
+        "description": "Get a list of applicable errata for a package.",
+        "parameters": [
+          {
+            "description": "NEVRA",
+            "in": "path",
+            "name": "nevra",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Patches"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get patches for a package"
+      }
+    },
+    "/pkglist": {
+      "post": {
+        "description": "Get details for all packages.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.PkgList"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get details for all packages"
+      }
+    },
+    "/pkgtree": {
+      "post": {
+        "description": "Get NEVRA trees for package names. Use `package_name_list` parameter to provide a list of package names, or a single POSIX regular expression.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vmaas.PkgTreeRequest",
+                    "summary": "package_name_list",
+                    "description": "package_name_list"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "package_name_list",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.PkgTree"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get NEVRA trees for package names"
+      }
+    },
+    "/pkgtree/{package_name}": {
+      "get": {
+        "description": "Get NEVRA tree for a package name. It is possible to use a POSIX regular expression as a pattern for package names.",
+        "parameters": [
+          {
+            "description": "package name",
+            "in": "path",
+            "name": "package_name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.PkgTree"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get NEVRA tree for a package name"
+      }
+    },
+    "/repos": {
+      "post": {
+        "description": "Get details about repositories. Use `repository_list` parameter to provide a list of repository names, or a single POSIX regular expression.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vmaas.ReposRequest",
+                    "summary": "repository_list",
+                    "description": "repository_list"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "repository_list",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Repos"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get details for repositories"
+      }
+    },
+    "/repos/{repo}": {
+      "get": {
+        "description": "Get details about a repository.\nIt is possible to use a POSIX regular expression as a pattern for repository names.",
+        "parameters": [
+          {
+            "description": "repository",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Repos"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get details for a repository"
+      }
+    },
+    "/updates": {
+      "post": {
+        "description": "List all updates for list of package NEVRAs.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vmaas.Request",
+                    "summary": "package_list",
+                    "description": "package_list"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "package_list",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Updates"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get updates for packages"
+      }
+    },
+    "/updates/{package}": {
+      "get": {
+        "description": "List all updates for single package NEVRA.",
+        "parameters": [
+          {
+            "description": "NEVRA",
+            "in": "path",
+            "name": "package",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Updates"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get updates for a package"
+      }
+    },
+    "/version": {
+      "get": {
+        "description": "Get VMaaS version.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get VMaaS version"
+      }
+    },
+    "/vulnerabilities": {
+      "post": {
+        "description": "Get a list of applicable CVEs for a package list.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vmaas.Request",
+                    "summary": "package_list",
+                    "description": "package_list"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "package_list",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/vmaas.Vulnerabilities"
+                    },
+                    {
+                      "$ref": "#/components/schemas/vmaas.VulnerabilitiesExtended"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "if request.extended"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get vulnerabilities for packages"
+      }
+    },
+    "/vulnerabilities/{package}": {
+      "get": {
+        "description": "Get a list of applicable CVEs for a single package NEVRA.",
+        "parameters": [
+          {
+            "description": "NEVRA",
+            "in": "path",
+            "name": "package",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vmaas.Vulnerabilities"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/utils.ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get vulnerabilities for a package"
+      }
+    }
+  },
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "/api/vmaas/v3"
+    }
+  ]
+}


### PR DESCRIPTION
Regenerate swagger api docs.
Note: you need to flush/disable the cache in order the docs to be reloaded, if you have not done before.


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Documentation:
- Regenerate the OpenAPI specification documentation to reflect the current API definition.