### PR TITLE
Fix flaky test_phase_1 by stopping leftover sync worker between reposcan tests

### DIFF
--- a/vmaas/reposcan/conftest.py
+++ b/vmaas/reposcan/conftest.py
@@ -61,6 +61,28 @@ EXPECTED_CSAF = (
 )
 
 
+@pytest.fixture(autouse=True)
+def _stop_leftover_sync_task():
+    """Ensure no background sync worker survives a test and pollutes the shared DB.
+
+    Reposcan API tests (e.g. test_add_repo_*) POST to /api/v1/repos, which starts an
+    asynchronous import in a separate spawned SyncTask worker process with its own DB
+    connection. That import is only best-effort cancelled by the test. If the worker is
+    still running when a later test runs, it can commit rows (such as the
+    'testing-repo-name' content_set) to the shared test database after that test's
+    reset_db(), causing intermittent failures like test_integration.test_phase_1
+    (assert 2 == 1). Terminate any worker still running at teardown so it cannot leak a
+    late commit across a test boundary; any row it already committed is then removed by
+    the next test's reset_db().
+    """
+    yield
+    # Imported lazily so collection never depends on the sync worker being initialized.
+    from vmaas.reposcan.reposcan import SyncTask  # pylint: disable=import-outside-toplevel
+
+    if SyncTask.workers is not None and SyncTask.is_running():
+        SyncTask.cancel()
+
+
 @pytest.fixture(scope="session")
 def db_conn():
     """Fixture for db connection."""


### PR DESCRIPTION
## Problem

`test_integration.py::test_phase_1` intermittently fails with:

```
assert 2 == 1
```

on the `content_set` row count, in CI on `master` and on the `foreman-*` branches. The failure is order/timing dependent and is not caused by any change in the source under test.

## Root cause

The reposcan API tests (`test/test_reposcan.py::test_add_repo_1` and `test_add_repo_1_with_certs`) POST a repo with content set `testing-repo-name` to `/api/v1/repos`. That endpoint starts an **asynchronous import** in a separate spawned `SyncTask` worker process (`multiprocessing.Pool(1)`, `spawn`) with its own DB connection, then only best-effort cancels it via `PUT /api/v1/task/cancel`.

If that worker is still running when a later test executes, it can commit the `testing-repo-name` `content_set` row to the shared test database **after** that test's `reset_db()` (`DROP SCHEMA public CASCADE`). `test_phase_1` then sees an extra row (`2`) instead of the `1` it just created, producing `assert 2 == 1`.

## Fix

Add an `autouse` teardown fixture in `vmaas/reposcan/conftest.py` that terminates any sync worker still running at the end of a test, so it cannot leak a late commit across a test boundary. Any row it may already have committed is removed by the next test's own `reset_db()`, since no live worker remains to re-add it. The fixture is a no-op when no worker is running.

This is a test-isolation change only; no production code is touched.

## Note for maintainers

This flaky test exists on `master` and all live `foreman-*` release branches (`foreman-5.0`, `foreman-3.18`, `foreman-3.16`), which share the same test infrastructure. The fix should be backported to all of them so CI is green everywhere.

## Summary by Sourcery

Stop leftover reposcan sync workers between tests to prevent late database commits and eliminate flaky integration-test failures.

Bug Fixes:
- Prevent background sync workers from leaking across reposcan tests and causing intermittent database row-count failures.

Enhancements:
- Improve test isolation by ensuring active asynchronous sync tasks are stopped during test teardown.