### PR TITLE
Stop leftover sync worker between reposcan tests (foreman-3.16)

### DIFF
--- a/vmaas/reposcan/conftest.py
+++ b/vmaas/reposcan/conftest.py
@@ -61,6 +61,28 @@ EXPECTED_CSAF = (
 )
 
 
+@pytest.fixture(autouse=True)
+def _stop_leftover_sync_task():
+    """Ensure no background sync worker survives a test and pollutes the shared DB.
+
+    Reposcan API tests (e.g. test_add_repo_*) POST to /api/v1/repos, which starts an
+    asynchronous import in a separate spawned SyncTask worker process with its own DB
+    connection. That import is only best-effort cancelled by the test. If the worker is
+    still running when a later test runs, it can commit rows (such as the
+    'testing-repo-name' content_set) to the shared test database after that test's
+    reset_db(), causing intermittent failures like test_integration.test_phase_1
+    (assert 2 == 1). Terminate any worker still running at teardown so it cannot leak a
+    late commit across a test boundary; any row it already committed is then removed by
+    the next test's reset_db().
+    """
+    yield
+    # Imported lazily so collection never depends on the sync worker being initialized.
+    from vmaas.reposcan.reposcan import SyncTask  # pylint: disable=import-outside-toplevel
+
+    if SyncTask.workers is not None and SyncTask.is_running():
+        SyncTask.cancel()
+
+
 @pytest.fixture(scope="session")
 def db_conn():
     """Fixture for db connection."""


### PR DESCRIPTION
Backport of #1942 (merged to `master`) to `foreman-3.16`.

Fixes the intermittent `test_integration.py::test_phase_1` failure (`assert 2 == 1` on the `content_set` count). The reposcan API tests start an asynchronous `SyncTask` import in a spawned worker that is only best-effort cancelled; if it is still running when a later test executes, it can commit a row after that test's `reset_db()`. This adds an autouse teardown that terminates any still-running sync worker at the test boundary so it cannot leak a late commit across tests.

Test-only change (`vmaas/reposcan/conftest.py`).

## Summary by Sourcery

Stop leftover reposcan sync workers from committing data after a test has reset the shared database.

Bug Fixes:
- Prevent asynchronous reposcan sync workers from leaking across tests and causing intermittent shared-database contamination.

Tests:
- Add an autouse reposcan test teardown that cancels any still-running sync worker at test boundaries.