### PR TITLE
fix: sha verification for older repos

### DIFF
--- a/vmaas/reposcan/repodata/checksum.py
+++ b/vmaas/reposcan/repodata/checksum.py
@@ -21,6 +21,10 @@ def verify_file_checksum(file_path, expected_checksum, checksum_type):
     # Map common checksum type names to hashlib algorithm names
     checksum_type = checksum_type.lower()
 
+    # Handle 'sha' checksum type from older repositories
+    if checksum_type == 'sha':
+        checksum_type = 'sha1'
+
     # Compute the file's checksum
     try:
         hasher = hashlib.new(checksum_type)

--- a/vmaas/reposcan/repodata/repository_controller.py
+++ b/vmaas/reposcan/repodata/repository_controller.py
@@ -167,7 +167,9 @@ class RepositoryController:
                     failed[local_path] = CHECKSUM_VERIFICATION_FAILED
                     FAILED_METADATA_CHECKSUM.inc()
                 except ValueError as err:
-                    self.logger.warning("Unsupported checksum type '%s' for %s: %s", checksum_type, local_path, str(err))
+                    self.logger.warning("Unsupported checksum type '%s' for %s (repo: %s, arch: %s, releasever: %s): %s",
+                                        checksum_type, local_path, repository.content_set, repository.basearch,
+                                        repository.releasever, str(err))
                     failed[local_path] = CHECKSUM_VERIFICATION_FAILED
                     FAILED_METADATA_CHECKSUM.inc()
                 except Exception:  # pylint: disable=broad-except

--- a/vmaas/reposcan/repodata/test/test_checksum.py
+++ b/vmaas/reposcan/repodata/test/test_checksum.py
@@ -80,6 +80,25 @@ class TestChecksum:
         finally:
             os.unlink(temp_path)
 
+    def test_transition_sha_checksum(self):
+        """
+        Test that legacy 'sha' checksum type is treated as 'sha1'.
+        Older repositories use checksum type='sha' in their repomd.xml.
+        This tests that 'sha' is silently mapped to 'sha1' for compatibility.
+        """
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
+            temp_file.write("test content\n")
+            temp_path = temp_file.name
+
+        # SHA1 of "test content\n"
+        expected = "4fe2b8dd12cd9cd6a413ea960cd8c09c25f19527"
+
+        try:
+            # Legacy 'sha' should be treated as 'sha1' and pass verification without error
+            verify_file_checksum(temp_path, expected, "sha")
+        finally:
+            os.unlink(temp_path)
+
     def test_case_insensitive_checksum(self):
         """Test whether checksum comparison is case-insensitive."""
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:


### PR DESCRIPTION
Older repos contains sha instead of sha1 sum checksum type. Added silent alias for this as these are the same hashes but different naming. Logging improved. Test added. RHINENG-30725

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Restore checksum verification compatibility for older repositories and improve diagnostic logging.

Bug Fixes:
- Support legacy repositories that identify SHA-1 checksums as `sha` during metadata verification.

Enhancements:
- Include repository, architecture, and release information in unsupported checksum warnings.

Tests:
- Add coverage for verifying checksums using the legacy `sha` checksum type.