### PR TITLE
[foreman-3.16] Fix CVE-2026-78676: bump GitPython to 3.1.62

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "botocore>=1.36.2",
     # Locked to 3.1.0 due to https://github.com/spec-first/connexion/issues/2029
     "connexion[swagger-ui]==3.1.0",
-    "gitpython>=3.1.58",
+    "gitpython>=3.1.59",
     "psycopg2-binary>=2.8.6",
     "prometheus-client>=0.8.0",
     "pyopenssl>=26.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -249,9 +249,9 @@ cryptography==48.0.0 ; python_version == "3.12" \
 gitdb==4.0.12 ; python_version == "3.12" \
     --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
     --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
-gitpython==3.1.58 ; python_version == "3.12" \
-    --hash=sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22 \
-    --hash=sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f
+gitpython==3.1.62 ; python_version == "3.12" \
+    --hash=sha256:1791de66309bc0c7cfca40bf8d2e3de7ca091cbf94e6051be1ad0722c61062af \
+    --hash=sha256:7002251225e10e29d2e1f49e6532613fe5d5d9f0b6f1f02997a52b38fe56899e
 h11==0.16.0 ; python_version == "3.12" \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
     --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86


### PR DESCRIPTION
Resolves CVE-2026-78676 (GitPython Remote Code Execution via config injection, fixed upstream in 3.1.59) by bumping GitPython to 3.1.62.